### PR TITLE
feat: guest 인증 구현 및 내 정보 조회 엔드포인트 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,6 @@ FRONTEND_URL="실제 개발 또는 배포 단계에서의 FrontEnd URL"
 
 # MCP SERVER
 MCP_SERVER_URL="실제 MCP server URL"
+
+# IP Hashing
+IP_SECRET_KEY="64자리 hex 문자열 (Guest 식별용)"

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,8 @@ import { RedisModule } from "./redis/redis.module";
         // JWT
         JWT_SECRET: Joi.string().required(),
         JWT_REFRESH_SECRET: Joi.string().required(),
+        // IP Hashing
+        IP_SECRET_KEY: Joi.string().length(64).required(),
         // Google OAuth
         GOOGLE_CLIENT_ID: Joi.string().required(),
         GOOGLE_CLIENT_SECRET: Joi.string().required(),

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -17,7 +17,7 @@ describe("AuthController", () => {
 
   const mockAuthService = {
     validateOAuthLogin: jest.fn(),
-    generateTokens: jest.fn(),
+    generateUserTokens: jest.fn(),
     refreshTokens: jest.fn(),
     findUserById: jest.fn(),
   };
@@ -122,7 +122,7 @@ describe("AuthController", () => {
       // given
       mockCacheManager.get.mockResolvedValue(user.id);
       mockAuthService.findUserById.mockResolvedValue(user);
-      mockAuthService.generateTokens.mockReturnValue(tokens);
+      mockAuthService.generateUserTokens.mockReturnValue(tokens);
 
       // when
       await controller.exchangeToken(code, mockResponse);

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -20,6 +20,8 @@ describe("AuthController", () => {
     generateUserTokens: jest.fn(),
     refreshTokens: jest.fn(),
     findUserById: jest.fn(),
+    getOrCreateGuest: jest.fn(),
+    generateGuestToken: jest.fn(),
   };
 
   const mockConfigService = {
@@ -173,6 +175,38 @@ describe("AuthController", () => {
       // then
       expect(result).toEqual(tokens);
       expect(mockAuthService.refreshTokens).toHaveBeenCalledWith(refreshTokenDto.refreshToken);
+    });
+  });
+
+  describe("me", () => {
+    it("should return guest info if user is guest", async () => {
+      const req: Parameters<typeof controller.me>[0] = {
+        user: { isGuest: true, ip: "127.0.0.1" },
+      };
+
+      mockAuthService.getOrCreateGuest.mockResolvedValue({
+        remainingUses: 3,
+        createdAt: Date.now(),
+      });
+
+      const result = await controller.me(req);
+
+      expect(mockAuthService.getOrCreateGuest).toHaveBeenCalledWith("127.0.0.1");
+      expect(result).toEqual({ isGuest: true, remainingUses: 3 });
+    });
+
+    it("should return user info if user is authenticated", async () => {
+      const req: Parameters<typeof controller.me>[0] = {
+        user: { isGuest: false, userId: "user-id", email: "test@example.com" },
+      };
+
+      const result = await controller.me(req);
+
+      expect(result).toEqual({
+        isGuest: false,
+        userId: "user-id",
+        email: "test@example.com",
+      });
     });
   });
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import {
   Body,
   Controller,
   Get,
+  Headers,
   Inject,
   Post,
   Req,
@@ -107,5 +108,27 @@ export class AuthController {
   @Post("refresh")
   async refresh(@Body() refreshTokenDto: RefreshTokenDto) {
     return this.authService.refreshTokens(refreshTokenDto.refreshToken);
+  }
+
+  /**
+   * POST /auth/guest
+   * 게스트 토큰 발급
+   */
+  @Post("guest")
+  async guest(@Headers("x-forwarded-for") forwardedFor?: string, @Req() req?: { ip?: string }) {
+    // IP 추출: X-Forwarded-For 헤더 또는 Express req.ip
+    const ip = forwardedFor?.split(",")[0].trim() || req?.ip || "unknown";
+
+    // 게스트 정보 조회 또는 생성
+    const guestInfo = await this.authService.getOrCreateGuest(ip);
+
+    // 토큰 발급
+    const accessToken = this.authService.generateGuestToken(ip);
+
+    return {
+      accessToken,
+      remainingUses: guestInfo.remainingUses,
+      isGuest: true,
+    };
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -131,4 +131,31 @@ export class AuthController {
       isGuest: true,
     };
   }
+
+  /**
+   * GET /auth/me
+   * 현재 인증된 사용자/게스트 정보 반환
+   */
+  @Get("me")
+  @UseGuards(AuthGuard("jwt"))
+  async me(
+    @Req() req: { user: { userId?: string; email?: string; ip?: string; isGuest: boolean } },
+  ) {
+    const { user } = req;
+
+    if (user.isGuest) {
+      const guestInfo = await this.authService.getOrCreateGuest(user.ip!);
+
+      return {
+        isGuest: true,
+        remainingUses: guestInfo.remainingUses,
+      };
+    }
+
+    return {
+      isGuest: false,
+      userId: user.userId,
+      email: user.email,
+    };
+  }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -85,7 +85,7 @@ export class AuthController {
       throw new UnauthorizedException("User not found");
     }
 
-    const tokens = this.authService.generateTokens(user.id, user.email);
+    const tokens = this.authService.generateUserTokens(user.id, user.email);
 
     // Refresh Token을 HttpOnly Cookie로 설정
     res.cookie("refreshToken", tokens.refreshToken, {

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -5,8 +5,10 @@ import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 import { redisStore } from "cache-manager-redis-yet";
 import { PrismaModule } from "../prisma/prisma.module";
+import { RedisModule } from "../redis/redis.module";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
+import { GuestRepository } from "./repositories/guest.repository";
 import { GoogleStrategy } from "./strategies/google.strategy";
 import { JwtStrategy } from "./strategies/jwt.strategy";
 
@@ -25,9 +27,10 @@ import { JwtStrategy } from "./strategies/jwt.strategy";
       }),
     }),
     PrismaModule,
+    RedisModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, GoogleStrategy, JwtStrategy],
+  providers: [AuthService, GuestRepository, GoogleStrategy, JwtStrategy],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -87,13 +87,13 @@ describe("AuthService", () => {
     });
   });
 
-  describe("generateTokens", () => {
+  describe("generateUserTokens", () => {
     it("should return access and refresh tokens", () => {
       // given
       mockJwtService.sign.mockReturnValue("mock-token");
 
       // when
-      const result = service.generateTokens("user-id", "test@example.com");
+      const result = service.generateUserTokens("user-id", "test@example.com");
 
       // then
       expect(result).toEqual({

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -4,7 +4,7 @@ import { JwtService } from "@nestjs/jwt";
 import { Test, type TestingModule } from "@nestjs/testing";
 import { PrismaService } from "../prisma/prisma.service";
 import { AuthService } from "./auth.service";
-import type { GoogleProfile, JwtPayload } from "./types/auth.types";
+import type { GoogleProfile, UserJwtPayload } from "./types/auth.types";
 
 describe("AuthService", () => {
   let service: AuthService;
@@ -106,7 +106,7 @@ describe("AuthService", () => {
 
   describe("refreshTokens", () => {
     const refreshToken = "valid-refresh-token";
-    const payload: JwtPayload = { id: "user-id", email: "test@example.com" };
+    const payload: UserJwtPayload = { id: "user-id", email: "test@example.com" };
 
     it("should return new tokens if refresh token is valid", async () => {
       // given

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -104,6 +104,19 @@ describe("AuthService", () => {
     });
   });
 
+  describe("generateGuestToken", () => {
+    it("should return access token", () => {
+      // given
+      mockJwtService.sign.mockReturnValue("mock-guest-token");
+
+      // when
+      const result = service.generateGuestToken("127.0.0.1");
+
+      // then
+      expect(result).toBe("mock-guest-token");
+    });
+  });
+
   describe("refreshTokens", () => {
     const refreshToken = "valid-refresh-token";
     const payload: UserJwtPayload = { id: "user-id", email: "test@example.com" };

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -4,6 +4,7 @@ import { JwtService } from "@nestjs/jwt";
 import { Test, type TestingModule } from "@nestjs/testing";
 import { PrismaService } from "../prisma/prisma.service";
 import { AuthService } from "./auth.service";
+import { GuestRepository } from "./repositories/guest.repository";
 import type { GoogleProfile, UserJwtPayload } from "./types/auth.types";
 
 describe("AuthService", () => {
@@ -37,6 +38,11 @@ describe("AuthService", () => {
     }),
   };
 
+  const mockGuestRepository = {
+    getGuestInfo: jest.fn(),
+    setGuestInfo: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -44,6 +50,7 @@ describe("AuthService", () => {
         { provide: PrismaService, useValue: mockPrismaService },
         { provide: JwtService, useValue: mockJwtService },
         { provide: ConfigService, useValue: mockConfigService },
+        { provide: GuestRepository, useValue: mockGuestRepository },
       ],
     }).compile();
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -44,7 +44,7 @@ export class AuthService {
    * - Access Token: 1시간 만료
    * - Refresh Token: 7일 만료
    */
-  generateTokens(userId: string, email: string): TokenPair {
+  generateUserTokens(userId: string, email: string): TokenPair {
     const payload: UserJwtPayload = { id: userId, email, jti: uuidv4() };
 
     const accessToken = this.jwtService.sign(payload, {
@@ -78,7 +78,7 @@ export class AuthService {
         throw new UnauthorizedException("User not found");
       }
 
-      return this.generateTokens(user.id, user.email);
+      return this.generateUserTokens(user.id, user.email);
     } catch {
       throw new UnauthorizedException("Invalid refresh token");
     }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,7 +3,10 @@ import { ConfigService } from "@nestjs/config";
 import { JwtService } from "@nestjs/jwt";
 import { v4 as uuidv4 } from "uuid";
 import { PrismaService } from "../prisma/prisma.service";
+import { GuestRepository } from "./repositories/guest.repository";
 import { GoogleProfile, GuestJwtPayload, TokenPair, UserJwtPayload } from "./types/auth.types";
+
+// TODO: 상수들 어떻게 관리할지 결정을 내려야겠다.
 
 @Injectable()
 export class AuthService {
@@ -11,6 +14,7 @@ export class AuthService {
     private readonly prisma: PrismaService,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
+    private readonly guestRepository: GuestRepository,
   ) {}
 
   /**
@@ -71,6 +75,21 @@ export class AuthService {
       secret: this.configService.getOrThrow<string>("JWT_SECRET"),
       expiresIn: "7d",
     });
+  }
+
+  /**
+   * 게스트 정보 조회 또는 생성
+   */
+  async getOrCreateGuest(ip: string) {
+    const existing = await this.guestRepository.getGuestInfo(ip);
+
+    if (existing) return existing;
+
+    const newGuest = { remainingUses: 3, createdAt: Date.now() };
+
+    await this.guestRepository.setGuestInfo(ip, newGuest);
+
+    return newGuest;
   }
 
   /**

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from "@nestjs/config";
 import { JwtService } from "@nestjs/jwt";
 import { v4 as uuidv4 } from "uuid";
 import { PrismaService } from "../prisma/prisma.service";
-import { GoogleProfile, TokenPair, UserJwtPayload } from "./types/auth.types";
+import { GoogleProfile, GuestJwtPayload, TokenPair, UserJwtPayload } from "./types/auth.types";
 
 @Injectable()
 export class AuthService {
@@ -58,6 +58,19 @@ export class AuthService {
     });
 
     return { accessToken, refreshToken };
+  }
+
+  /**
+   * 게스트용 Access Token 생성
+   * - 게스트는 Refresh Token 없음 (단기 세션)
+   */
+  generateGuestToken(ip: string): string {
+    const payload: GuestJwtPayload = { ip, isGuest: true, jti: uuidv4() };
+
+    return this.jwtService.sign(payload, {
+      secret: this.configService.getOrThrow<string>("JWT_SECRET"),
+      expiresIn: "7d",
+    });
   }
 
   /**

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from "@nestjs/config";
 import { JwtService } from "@nestjs/jwt";
 import { v4 as uuidv4 } from "uuid";
 import { PrismaService } from "../prisma/prisma.service";
-import { GoogleProfile, JwtPayload, TokenPair } from "./types/auth.types";
+import { GoogleProfile, TokenPair, UserJwtPayload } from "./types/auth.types";
 
 @Injectable()
 export class AuthService {
@@ -45,7 +45,7 @@ export class AuthService {
    * - Refresh Token: 7일 만료
    */
   generateTokens(userId: string, email: string): TokenPair {
-    const payload: JwtPayload = { id: userId, email, jti: uuidv4() };
+    const payload: UserJwtPayload = { id: userId, email, jti: uuidv4() };
 
     const accessToken = this.jwtService.sign(payload, {
       secret: this.configService.getOrThrow<string>("JWT_SECRET"),
@@ -66,7 +66,7 @@ export class AuthService {
    */
   async refreshTokens(refreshToken: string): Promise<TokenPair> {
     try {
-      const payload = this.jwtService.verify<JwtPayload>(refreshToken, {
+      const payload = this.jwtService.verify<UserJwtPayload>(refreshToken, {
         secret: this.configService.getOrThrow<string>("JWT_REFRESH_SECRET"),
       });
 

--- a/src/auth/repositories/guest.repository.ts
+++ b/src/auth/repositories/guest.repository.ts
@@ -1,0 +1,27 @@
+import { Injectable } from "@nestjs/common";
+import { RedisService } from "../../redis/redis.service";
+import { GuestInfo } from "../types/auth.types";
+
+// TODO: 상수폴더를 생성해서 옮길지 환경변수로 뺄지 결정하기
+const DEFAULT_GUEST_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+@Injectable()
+export class GuestRepository {
+  constructor(private readonly redisService: RedisService) {}
+
+  async getGuestInfo(ip: string): Promise<GuestInfo | null> {
+    const data = await this.redisService.getClient().get(`guest:${ip}`);
+
+    if (!data) return null;
+
+    return JSON.parse(data) as GuestInfo;
+  }
+
+  async setGuestInfo(
+    ip: string,
+    info: GuestInfo,
+    ttlSeconds: number = DEFAULT_GUEST_TTL_SECONDS,
+  ): Promise<void> {
+    await this.redisService.getClient().set(`guest:${ip}`, JSON.stringify(info), "EX", ttlSeconds);
+  }
+}

--- a/src/auth/repositories/guest.repository.ts
+++ b/src/auth/repositories/guest.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { RedisService } from "../../redis/redis.service";
 import { GuestInfo } from "../types/auth.types";
+import { hashIp } from "../utils/ip-hash.util";
 
 // TODO: 상수폴더를 생성해서 옮길지 환경변수로 뺄지 결정하기
 const DEFAULT_GUEST_TTL_SECONDS = 7 * 24 * 60 * 60;
@@ -10,7 +11,8 @@ export class GuestRepository {
   constructor(private readonly redisService: RedisService) {}
 
   async getGuestInfo(ip: string): Promise<GuestInfo | null> {
-    const data = await this.redisService.getClient().get(`guest:${ip}`);
+    const hashedIp = hashIp(ip);
+    const data = await this.redisService.getClient().get(`guest:${hashedIp}`);
 
     if (!data) return null;
 
@@ -22,6 +24,9 @@ export class GuestRepository {
     info: GuestInfo,
     ttlSeconds: number = DEFAULT_GUEST_TTL_SECONDS,
   ): Promise<void> {
-    await this.redisService.getClient().set(`guest:${ip}`, JSON.stringify(info), "EX", ttlSeconds);
+    const hashedIp = hashIp(ip);
+    await this.redisService
+      .getClient()
+      .set(`guest:${hashedIp}`, JSON.stringify(info), "EX", ttlSeconds);
   }
 }

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { PassportStrategy } from "@nestjs/passport";
 import { ExtractJwt, Strategy } from "passport-jwt";
-import { UserJwtPayload } from "../types/auth.types";
+import { GuestJwtPayload, UserJwtPayload } from "../types/auth.types";
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
@@ -14,19 +14,24 @@ export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
     });
   }
 
-  /**
-   * JWT 검증 성공 후 호출되는 메서드
-   * @param payload - JWT 페이로드 (id, email 등)
-   * @returns req.user에 저장될 사용자 정보
-   */
-  validate(payload: UserJwtPayload): { userId: string; email: string } {
-    if (!payload.id || !payload.email) {
+  validate(payload: UserJwtPayload | GuestJwtPayload) {
+    if ("isGuest" in payload) {
+      return {
+        ip: payload.ip,
+        isGuest: true,
+      };
+    }
+
+    const userPayload = payload;
+
+    if (!userPayload.id || !userPayload.email) {
       throw new UnauthorizedException("Invalid token payload");
     }
 
     return {
-      userId: payload.id,
-      email: payload.email,
+      userId: userPayload.id,
+      email: userPayload.email,
+      isGuest: false,
     };
   }
 }

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { PassportStrategy } from "@nestjs/passport";
 import { ExtractJwt, Strategy } from "passport-jwt";
-import { JwtPayload } from "../types/auth.types";
+import { UserJwtPayload } from "../types/auth.types";
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
@@ -19,7 +19,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
    * @param payload - JWT 페이로드 (id, email 등)
    * @returns req.user에 저장될 사용자 정보
    */
-  validate(payload: JwtPayload): { userId: string; email: string } {
+  validate(payload: UserJwtPayload): { userId: string; email: string } {
     if (!payload.id || !payload.email) {
       throw new UnauthorizedException("Invalid token payload");
     }

--- a/src/auth/types/auth.types.ts
+++ b/src/auth/types/auth.types.ts
@@ -1,9 +1,9 @@
 import type { Request } from "express";
 
 /**
- * JWT 페이로드 구조
+ * User JWT 페이로드 구조
  */
-export interface JwtPayload {
+export interface UserJwtPayload {
   id: string;
   email: string;
   jti?: string;

--- a/src/auth/types/auth.types.ts
+++ b/src/auth/types/auth.types.ts
@@ -10,6 +10,23 @@ export interface UserJwtPayload {
 }
 
 /**
+ * Guest JWT 페이로드 구조
+ */
+export interface GuestJwtPayload {
+  ip: string;
+  isGuest: true;
+  jti?: string;
+}
+
+/**
+ * Redis에 저장될 게스트 정보
+ */
+export interface GuestInfo {
+  remainingUses: number;
+  createdAt: number;
+}
+
+/**
  * Google OAuth 사용자 프로필
  */
 export interface GoogleProfile {

--- a/src/auth/utils/ip-hash.util.ts
+++ b/src/auth/utils/ip-hash.util.ts
@@ -1,0 +1,18 @@
+import * as crypto from "crypto";
+
+/**
+ * IP 주소를 HMAC-SHA256으로 해싱합니다.
+ * 개인정보 보호를 위해 원본 IP 대신 해시값을 Redis 키로 사용합니다.
+ *
+ * @param ip - 해싱할 IP 주소
+ * @returns 64자리 hex 문자열
+ */
+export function hashIp(ip: string): string {
+  const key = process.env.IP_SECRET_KEY;
+
+  if (!key) {
+    throw new Error("IP_SECRET_KEY is not defined in environment variables");
+  }
+
+  return crypto.createHmac("sha256", key).update(ip).digest("hex");
+}

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -145,7 +145,7 @@ describe("AuthController (e2e)", () => {
       });
 
       // 2. 유효한 Refresh Token 생성
-      const tokens = authService.generateTokens(user.id, user.email);
+      const tokens = authService.generateUserTokens(user.id, user.email);
       const refreshToken = tokens.refreshToken;
 
       // 3. 갱신 요청


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Closes #4 

## 🛠️ 작업 내용 (Description)
- **AS-IS**
  - 로그인한 사용자만 서비스 이용 가능
  - 단일 `JwtPayload`, `generateTokens` 구조
  
- **TO-BE**
  - 비로그인 사용자(게스트)도 제한된 횟수(3회) 내에서 서비스 이용 가능
  - User/Guest 로직 명시적 분리: `UserJwtPayload`/`GuestJwtPayload`, `generateUserTokens`/`generateGuestToken`
  - Redis 기반 게스트 사용량 관리 (7일 TTL)

### 주요 변경사항

#### 1. 기존 로직 리네이밍 (User 명시화)
- `JwtPayload` → `UserJwtPayload`
- `generateTokens()` → `generateUserTokens()`

#### 2. Guest 타입 및 로직 추가
- `GuestJwtPayload` 인터페이스 추가 (`ip`, `isGuest: true`)
- `GuestInfo` 인터페이스 추가 (`remainingUses`, `createdAt`)
- `GuestRepository` 신규 생성 (Redis 게스트 정보 관리)
- `generateGuestToken()` 메서드 추가

#### 3. 엔드포인트 구현
- **POST /auth/guest**: 게스트 토큰 발급
  - `X-Forwarded-For` 헤더로 IP 추출
  - 응답: `{ accessToken, remainingUses, isGuest: true }`
  
- **GET /auth/me**: 현재 인증 정보 조회
  - 게스트: `{ isGuest: true, remainingUses }`
  - 유저: `{ isGuest: false, userId, email }`

#### 4. JwtStrategy 게스트 지원
- 단일 Strategy에서 `isGuest` 필드로 분기 처리
- 게스트 토큰: `{ ip, isGuest: true }` 반환
- 유저 토큰: `{ userId, email, isGuest: false }` 반환

## ✅ 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?
- [x] (필요 시) 관련 문서나 API 명세서를 업데이트했나요?

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요? (변경 없음)
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)

### 게스트 토큰 발급
```bash
curl -X POST http://localhost:3000/auth/guest \
  -H "X-Forwarded-For: 123.456.789.0"
```

### 게스트 정보 조회
```bash
curl http://localhost:3000/auth/me \
  -H "Authorization: Bearer {게스트_액세스_토큰}"
```

### 유저 정보 조회
1. 브라우저에서 http://localhost:3000/auth/google 로 접속(GET)
2. google OAuth 진행
3. 브라우저에서 리다이렉트된 URL 확인 (ex: http://localhost:3000/?code=69a8ed55-66a6-4b7d-8e5c-1d2a9bc88f7f)
4. POSTMAN을 이용하여 POST http://localhost:3000/auth/token 으로 body를 아래와 같이 설정
```json
{
  "code": "69a8ed55-66a6-4b7d-8e5c-1d2a9bc88f7f"
}
```
5. 응답에서 `accessToken` 값 확인
```json
{
  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
}
```
6. POSTMAN에서 GET http://localhost:3000/auth/me 요청
   - Headers에 `Authorization: Bearer {위에서 받은 accessToken}` 추가
7. 응답 확인
```json
{
  "isGuest": false,
  "userId": "2e93c9b8-...",
  "email": "user@example.com"
}
```

## ⚠️ 특이사항 (Notes)
- JwtStrategy 는 현재 분기 처리 방식을 선택했습니다.
- `auth/me` 응답 구조에서 user 의 경우 'isGuest: false' 를 추가했습니다.
- 상수 관리 방식(상수 폴더 vs 환경변수) 결정이 필요할 것 같습니다. (TODO 남겨둠)
