### PR TITLE
feat: Factcheck - PATCH apply/ignore 구현

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,7 +64,7 @@ model FactCheck {
 // 4. 문장 (Sentence) - position 방식
 // ====================================
 model Sentence {
-  id       Int          @id @default(autoincrement())
+  id       String       @id @default(uuid())
   type     SentenceType // CLAIM, OPINION (EXCLUDED는 저장 안 함)
   text     String       @db.Text
   position Int          // 문장 순서 (0부터 시작)

--- a/src/factcheck/dto/factcheck-response.dto.ts
+++ b/src/factcheck/dto/factcheck-response.dto.ts
@@ -13,8 +13,14 @@ export interface BaseSentenceResponse {
   position: number;
 }
 
-// Claim 상태 (BE-07에서도 사용)
+// Claim 상태 (조회 시)
 export type ClaimStatusResponse = "pending" | "applied" | "ignored";
+
+// Claim 상태 업데이트 응답 (apply/ignore API)
+export interface ClaimStatusUpdateResponse {
+  id: string;
+  status: Exclude<ClaimStatusResponse, "pending">;
+}
 
 // Claim 문장 응답
 export interface ClaimSentenceResponse extends BaseSentenceResponse {

--- a/src/factcheck/factcheck.controller.ts
+++ b/src/factcheck/factcheck.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  Patch,
   Post,
   Query,
   Request,
@@ -13,8 +14,8 @@ import {
 import { CurrentUser } from "../common/decorators/current-user.decorator";
 import { RequireLogin } from "../common/decorators/require-login.decorator";
 import { CreateFactCheckDto } from "./dto/create-factcheck.dto";
-import { FactCheckListResponse } from "./dto/factcheck-list-response.dto";
-import { FactCheckResponse } from "./dto/factcheck-response.dto";
+import type { FactCheckListResponse } from "./dto/factcheck-list-response.dto";
+import type { ClaimStatusUpdateResponse, FactCheckResponse } from "./dto/factcheck-response.dto";
 import { GetFactCheckListQueryDto } from "./dto/pagination-query.dto";
 import { FactCheckService } from "./factcheck.service";
 import type { AuthenticatedUser, RequestWithUser } from "./types/factcheck.types";
@@ -58,5 +59,25 @@ export class FactCheckController {
     @Param("id") id: string,
   ): Promise<{ success: boolean }> {
     return this.factCheckService.deleteFactCheck(user, id);
+  }
+
+  @Patch(":id/claims/:claimId/apply")
+  @HttpCode(HttpStatus.OK)
+  async apply(
+    @Request() req: RequestWithUser,
+    @Param("id") id: string,
+    @Param("claimId") claimId: string,
+  ): Promise<ClaimStatusUpdateResponse> {
+    return this.factCheckService.applyClaim(req.user, id, claimId);
+  }
+
+  @Patch(":id/claims/:claimId/ignore")
+  @HttpCode(HttpStatus.OK)
+  async ignore(
+    @Request() req: RequestWithUser,
+    @Param("id") id: string,
+    @Param("claimId") claimId: string,
+  ): Promise<ClaimStatusUpdateResponse> {
+    return this.factCheckService.ignoreClaim(req.user, id, claimId);
   }
 }

--- a/src/factcheck/factcheck.service.ts
+++ b/src/factcheck/factcheck.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
   NotFoundException,
 } from "@nestjs/common";
-import type { Sentence } from "@prisma/client";
+import { ClaimStatus, type Sentence } from "@prisma/client";
 import { v4 as uuidv4 } from "uuid";
 import { GuestRepository } from "../auth/repositories/guest.repository";
 import { McpService } from "../mcp/mcp.service";
@@ -14,6 +14,7 @@ import { CLAIM_STATUS_MAP } from "./constants";
 import type { FactCheckListResponse } from "./dto/factcheck-list-response.dto";
 import type {
   ClaimSentenceResponse,
+  ClaimStatusUpdateResponse,
   FactCheckResponse,
   FactCheckSource,
   FactCheckSummary,
@@ -261,5 +262,50 @@ export class FactCheckService {
     }
 
     return { success: true };
+  }
+
+  async applyClaim(
+    user: RequestUser,
+    factCheckId: string,
+    claimId: string,
+  ): Promise<ClaimStatusUpdateResponse> {
+    return this.updateStatus(user, factCheckId, claimId, ClaimStatus.APPLIED);
+  }
+
+  async ignoreClaim(
+    user: RequestUser,
+    factCheckId: string,
+    claimId: string,
+  ): Promise<ClaimStatusUpdateResponse> {
+    return this.updateStatus(user, factCheckId, claimId, ClaimStatus.IGNORED);
+  }
+
+  private async updateStatus(
+    user: RequestUser,
+    factCheckId: string,
+    claimId: string,
+    targetStatus: ClaimStatus,
+  ): Promise<ClaimStatusUpdateResponse> {
+    const statusValue = CLAIM_STATUS_MAP[targetStatus] as "applied" | "ignored";
+
+    if (user.isGuest) {
+      return { id: claimId, status: statusValue };
+    }
+
+    const updated = await this.factCheckRepository.updateClaimStatus(
+      user.userId,
+      factCheckId,
+      claimId,
+      targetStatus,
+    );
+
+    if (!updated) {
+      throw new NotFoundException({
+        error: "CLAIM_NOT_FOUND",
+        message: "해당 항목을 찾을 수 없거나 이미 처리되었습니다.",
+      });
+    }
+
+    return { id: claimId, status: statusValue };
   }
 }

--- a/src/factcheck/repositories/factcheck.repository.ts
+++ b/src/factcheck/repositories/factcheck.repository.ts
@@ -28,6 +28,7 @@ export class FactCheckRepository {
           create: sentences.map((sentence) => {
             if (sentence.type === "claim") {
               return {
+                id: sentence.id,
                 type: SentenceType.CLAIM,
                 text: sentence.text,
                 position: sentence.position,
@@ -38,6 +39,7 @@ export class FactCheckRepository {
               };
             } else {
               return {
+                id: sentence.id,
                 type: SentenceType.OPINION,
                 text: sentence.text,
                 position: sentence.position,
@@ -93,6 +95,26 @@ export class FactCheckRepository {
         id: factCheckId,
         userId,
       },
+    });
+    return result.count > 0;
+  }
+
+  async updateClaimStatus(
+    userId: string,
+    factCheckId: string,
+    claimId: string,
+    status: ClaimStatus,
+  ): Promise<boolean> {
+    const result = await this.prisma.sentence.updateMany({
+      where: {
+        id: claimId,
+        factCheck: {
+          id: factCheckId,
+          userId,
+        },
+        type: SentenceType.CLAIM,
+      },
+      data: { status },
     });
     return result.count > 0;
   }

--- a/src/mcp/mcp.service.spec.ts
+++ b/src/mcp/mcp.service.spec.ts
@@ -4,6 +4,10 @@ import { Test, type TestingModule } from "@nestjs/testing";
 import { McpService } from "./mcp.service";
 import type { McpResponse } from "./types/mcp.types";
 
+jest.mock("uuid", () => ({
+  v4: jest.fn().mockReturnValue("test-uuid"),
+}));
+
 describe("McpService", () => {
   let service: McpService;
 
@@ -18,6 +22,7 @@ describe("McpService", () => {
         endIndex: 20,
         verdict: "TRUE",
         sources: [{ title: "출처", url: "https://example.com" }],
+        suggestion: null,
       },
       {
         type: "opinion",
@@ -25,6 +30,7 @@ describe("McpService", () => {
         startIndex: 21,
         endIndex: 35,
         reason: "주관적 표현 포함",
+        suggestion: null,
       },
     ],
   };
@@ -43,6 +49,9 @@ describe("McpService", () => {
     }).compile();
 
     service = module.get<McpService>(McpService);
+
+    // Reset fetch mock before each test
+    global.fetch = jest.fn();
   });
 
   afterEach(() => {
@@ -52,30 +61,53 @@ describe("McpService", () => {
   describe("analyze", () => {
     it("정상 응답 시 McpResponse를 반환해야 한다", async () => {
       // Arrange
-      global.fetch = jest.fn().mockResolvedValue({
+      (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
-        json: jest.fn().mockResolvedValue(mockMcpResponse),
-      });
+        json: jest.fn().mockResolvedValue({
+          jsonrpc: "2.0",
+          id: "test-id",
+          result: {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(mockMcpResponse),
+              },
+            ],
+          },
+        }),
+      } as Partial<Response>);
 
       // Act
       const result = await service.analyze("테스트 텍스트");
 
       // Assert
       expect(result).toEqual(mockMcpResponse);
+      expect(result.sentences).toHaveLength(2);
+      expect(result.sentences[0].type).toBe("claim");
+      expect(result.sentences[1].type).toBe("opinion");
+
       expect(fetch).toHaveBeenCalledWith("http://localhost:8000/mcp", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: "테스트 텍스트" }),
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "test-uuid",
+          method: "tools/call",
+          params: {
+            name: "factcheck",
+            arguments: { text: "테스트 텍스트" },
+          },
+        }),
       });
     });
 
     it("서버가 500 에러를 반환하면 BadGatewayException을 던져야 한다", async () => {
       // Arrange
-      global.fetch = jest.fn().mockResolvedValue({
+      (global.fetch as jest.Mock).mockResolvedValue({
         ok: false,
         status: 500,
         statusText: "Internal Server Error",
-      });
+      } as Partial<Response>);
 
       // Act & Assert
       await expect(service.analyze("테스트 텍스트")).rejects.toThrow(BadGatewayException);
@@ -84,7 +116,7 @@ describe("McpService", () => {
 
     it("네트워크 오류 시 BadGatewayException을 던져야 한다", async () => {
       // Arrange
-      global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+      (global.fetch as jest.Mock).mockRejectedValue(new Error("Network error"));
 
       // Act & Assert
       await expect(service.analyze("테스트 텍스트")).rejects.toThrow(BadGatewayException);

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -1,6 +1,7 @@
 import { BadGatewayException, Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { McpResponse } from "./types/mcp.types";
+import { v4 as uuidv4 } from "uuid";
+import { JsonRpcResponse, McpResponse } from "./types/mcp.types";
 
 @Injectable()
 export class McpService {
@@ -12,14 +13,14 @@ export class McpService {
   }
 
   /**
-   * MCP 서버에 텍스트 분석 요청
+   * MCP 서버에 텍스트 분석 요청 (JSON-RPC 2.0)
    * @param text 분석할 텍스트
    * @returns MCP 서버의 분석 결과
    * @throws BadGatewayException MCP 서버 호출 실패 시
    */
   async analyze(text: string): Promise<McpResponse> {
     const startTime = Date.now();
-    this.logger.log(`MCP 서버 요청 시작 - 텍스트 길이: ${text.length}`);
+    this.logger.log(`MCP 서버 요청 시작 (JSON-RPC) - 텍스트 길이: ${text.length}`);
 
     try {
       const response = await fetch(`${this.mcpServerUrl}/mcp`, {
@@ -27,7 +28,15 @@ export class McpService {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ text }),
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: uuidv4(),
+          method: "tools/call",
+          params: {
+            name: "factcheck",
+            arguments: { text },
+          },
+        }),
       });
 
       if (!response.ok) {
@@ -35,7 +44,21 @@ export class McpService {
         throw new BadGatewayException("MCP_ERROR");
       }
 
-      const data = (await response.json()) as McpResponse;
+      const jsonRpcResponse = (await response.json()) as unknown as JsonRpcResponse;
+
+      if ("error" in jsonRpcResponse && jsonRpcResponse.error) {
+        this.logger.error(`MCP RPC 에러: ${JSON.stringify(jsonRpcResponse.error)}`);
+        throw new BadGatewayException("MCP_ERROR");
+      }
+
+      // 성공 응답: result.content[0].text에 JSON 문자열로 들어있음
+      const content = jsonRpcResponse.result.content[0];
+      if (!content || content.type !== "text") {
+        this.logger.error("MCP 서버로부터 예상치 못한 응답 형식을 받았습니다.");
+        throw new BadGatewayException("MCP_ERROR");
+      }
+
+      const data = JSON.parse(content.text) as McpResponse;
       const elapsedTime = Date.now() - startTime;
       this.logger.log(
         `MCP 서버 응답 성공 - 소요 시간: ${elapsedTime}ms, 문장 수: ${data.sentences?.length ?? 0}`,

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -51,6 +51,11 @@ export class McpService {
         throw new BadGatewayException("MCP_ERROR");
       }
 
+      if (!jsonRpcResponse.result) {
+        this.logger.error(`MCP 서버 응답에 result가 없습니다: ${JSON.stringify(jsonRpcResponse)}`);
+        throw new BadGatewayException("MCP_ERROR");
+      }
+
       // 성공 응답: result.content[0].text에 JSON 문자열로 들어있음
       const content = jsonRpcResponse.result.content[0];
       if (!content || content.type !== "text") {

--- a/src/mcp/types/mcp.types.ts
+++ b/src/mcp/types/mcp.types.ts
@@ -29,3 +29,33 @@ export interface McpResponse {
   originalText: string;
   sentences: McpSentence[];
 }
+
+// JSON-RPC 2.0 응답 타입 (MCP 서버 통신용)
+interface JsonRpcContentItem {
+  type: string;
+  text: string;
+}
+
+interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+interface JsonRpcSuccessResponse {
+  jsonrpc: "2.0";
+  id: string;
+  result: {
+    content: JsonRpcContentItem[];
+  };
+  error?: never;
+}
+
+interface JsonRpcErrorResponse {
+  jsonrpc: "2.0";
+  id: string | null;
+  result?: never;
+  error: JsonRpcError;
+}
+
+export type JsonRpcResponse = JsonRpcSuccessResponse | JsonRpcErrorResponse;

--- a/test/factcheck-claim-status.e2e-spec.ts
+++ b/test/factcheck-claim-status.e2e-spec.ts
@@ -1,0 +1,180 @@
+import type { Server } from "http";
+import { CACHE_MANAGER } from "@nestjs/cache-manager";
+import { ValidationPipe, type INestApplication } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { JwtService } from "@nestjs/jwt";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ClaimStatus } from "@prisma/client";
+import request from "supertest";
+import { v4 as uuidv4 } from "uuid";
+import { AppModule } from "../src/app.module";
+import { McpService } from "../src/mcp/mcp.service";
+import { PrismaService } from "../src/prisma/prisma.service";
+
+describe("FactCheck Claim Status (e2e)", () => {
+  let app: INestApplication;
+  let jwtService: JwtService;
+  let configService: ConfigService;
+  let prismaService: PrismaService;
+
+  const TEST_USER_EMAIL = "fc-status-user@example.com";
+  const TEST_USER_ID = "fc-status-user-id";
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(McpService)
+      .useValue({ analyze: jest.fn() }) // Mock unused service
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+
+    await app.init();
+
+    jwtService = moduleFixture.get<JwtService>(JwtService);
+    configService = moduleFixture.get<ConfigService>(ConfigService);
+    prismaService = moduleFixture.get<PrismaService>(PrismaService);
+
+    // 테스트 유저 생성
+    await prismaService.user.upsert({
+      where: { email: TEST_USER_EMAIL },
+      update: {},
+      create: {
+        id: TEST_USER_ID,
+        email: TEST_USER_EMAIL,
+        name: "FactCheck Status User",
+        provider: "google",
+        providerId: "fc-status-google-123",
+      },
+    });
+  });
+
+  afterEach(async () => {
+    // 각 테스트 후 생성된 FactCheck 데이터 정리
+    await prismaService.factCheck.deleteMany({ where: { userId: TEST_USER_ID } });
+  });
+
+  afterAll(async () => {
+    // Clean up
+    await prismaService.factCheck.deleteMany({ where: { userId: TEST_USER_ID } });
+    await prismaService.user.deleteMany({ where: { email: TEST_USER_EMAIL } });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+    const cacheManager: any = app.get(CACHE_MANAGER);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (cacheManager.store?.client?.quit) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      await cacheManager.store.client.quit();
+    }
+
+    await prismaService.$disconnect();
+    await app.close();
+  });
+
+  const generateUserToken = () => {
+    return jwtService.sign(
+      { id: TEST_USER_ID, email: TEST_USER_EMAIL },
+      { secret: configService.get<string>("JWT_SECRET") },
+    );
+  };
+
+  const generateGuestToken = () => {
+    return jwtService.sign(
+      { ip: "test-status-ip", isGuest: true },
+      { secret: configService.get<string>("JWT_SECRET") },
+    );
+  };
+
+  const createTestFactCheck = async () => {
+    const factCheckId = uuidv4();
+    const claimId = uuidv4();
+
+    await prismaService.factCheck.create({
+      data: {
+        id: factCheckId,
+        userId: TEST_USER_ID,
+        title: "Test Title",
+        originalText: "Test Text",
+        sentences: {
+          create: [
+            {
+              id: claimId,
+              type: "CLAIM",
+              text: "Test Claim",
+              position: 0,
+              status: "PENDING",
+            },
+          ],
+        },
+      },
+    });
+
+    return { factCheckId, claimId };
+  };
+
+  describe("PATCH /factcheck/:id/claims/:claimId/apply", () => {
+    let factCheckId: string;
+    let claimId: string;
+
+    beforeEach(async () => {
+      const testData = await createTestFactCheck();
+      factCheckId = testData.factCheckId;
+      claimId = testData.claimId;
+    });
+
+    it("🔴 로그인 사용자: Claim을 승인(Apply)하면 상태가 APPLIED로 변경되어야 한다", async () => {
+      // Act
+      const response = await request(app.getHttpServer() as Server)
+        .patch(`/factcheck/${factCheckId}/claims/${claimId}/apply`)
+        .set("Authorization", `Bearer ${generateUserToken()}`)
+        .expect(200);
+
+      // Assert Response
+      expect((response.body as { status: string }).status).toBe("applied");
+
+      // Assert DB
+      const updated = await prismaService.sentence.findUnique({ where: { id: claimId } });
+      expect(updated?.status).toBe(ClaimStatus.APPLIED);
+    });
+
+    it("🔴 게스트 사용자: 승인 요청 시 성공 응답을 받지만 DB는 변경되지 않아야 한다 (No-op)", async () => {
+      // Act
+      const response = await request(app.getHttpServer() as Server)
+        .patch(`/factcheck/${factCheckId}/claims/${claimId}/apply`)
+        .set("Authorization", `Bearer ${generateGuestToken()}`)
+        .expect(200);
+
+      // Assert Response
+      expect((response.body as { status: string }).status).toBe("applied");
+
+      // Assert DB (Should remain PENDING)
+      const notUpdated = await prismaService.sentence.findUnique({ where: { id: claimId } });
+      expect(notUpdated?.status).toBe(ClaimStatus.PENDING);
+    });
+  });
+
+  describe("PATCH /factcheck/:id/claims/:claimId/ignore", () => {
+    let factCheckId: string;
+    let claimId: string;
+
+    beforeEach(async () => {
+      const testData = await createTestFactCheck();
+      factCheckId = testData.factCheckId;
+      claimId = testData.claimId;
+    });
+
+    it("🔴 로그인 사용자: Claim을 무시(Ignore)하면 상태가 IGNORED로 변경되어야 한다", async () => {
+      const response = await request(app.getHttpServer() as Server)
+        .patch(`/factcheck/${factCheckId}/claims/${claimId}/ignore`)
+        .set("Authorization", `Bearer ${generateUserToken()}`)
+        .expect(200);
+
+      expect((response.body as { status: string }).status).toBe("ignored");
+
+      const updated = await prismaService.sentence.findUnique({ where: { id: claimId } });
+      expect(updated?.status).toBe(ClaimStatus.IGNORED);
+    });
+  });
+});

--- a/test/factcheck.e2e-spec.ts
+++ b/test/factcheck.e2e-spec.ts
@@ -28,6 +28,7 @@ describe("FactCheck (e2e)", () => {
         startIndex: 0,
         endIndex: 20,
         verdict: "TRUE",
+        suggestion: null,
         sources: [{ title: "출처", url: "https://example.com" }],
       },
       {
@@ -36,6 +37,7 @@ describe("FactCheck (e2e)", () => {
         startIndex: 21,
         endIndex: 35,
         reason: "주관적 표현",
+        suggestion: null,
       },
     ],
   };
@@ -174,9 +176,6 @@ describe("FactCheck (e2e)", () => {
     describe("Success Response", () => {
       it("로그인 사용자의 정상 요청은 201 Created를 반환해야 한다", async () => {
         const token = generateUserToken();
-
-        // (삭제됨: beforeAll에서 이미 생성함)
-
         const response: Response = await request(app.getHttpServer() as Server)
           .post("/factcheck")
           .set("Authorization", `Bearer ${token}`)


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Closes #12

## 🛠️ 작업 내용 (Description)

### AS-IS
- 팩트체크 결과(Claim)에 대한 사용자 적용/무시 기능 미구현
- MCP 서버와의 통신이 JSON-RPC 2.0 규격과 불일치

### TO-BE
- **Claim Apply/Ignore API 구현 (BE-07)**
  - `PATCH /factcheck/:id/claims/:claimId/apply` - Claim 상태를 `applied`로 변경
  - `PATCH /factcheck/:id/claims/:claimId/ignore` - Claim 상태를 `ignored`로 변경
  - 게스트 사용자: DB 저장 없이 성공 응답 반환 (No-op)
  - 로그인 사용자: DB에 상태 변경 저장
  
- **MCP 서버 통신 수정**
  - JSON-RPC 2.0 규격(`jsonrpc`, `method`, `params`, `id`)에 맞게 요청 형식 수정
  - `tools/call` 메서드를 통한 `factcheck` 도구 호출
  - 중첩된 응답 구조(`result.content[0].text`) 파싱 로직 구현

### 주요 변경사항

#### 1. DB Schema 변경
- `Sentence.id` 타입: `Int (Auto-increment)` → `String (UUID)`
- 사유: Service에서 생성하는 UUID와 DB ID 타입 일치

#### 2. FactCheck 모듈 API 확장
| 파일 | 변경 내용 |
|------|-----------|
| `factcheck.controller.ts` | apply/ignore 엔드포인트 추가, 반환 타입 명시 |
| `factcheck.service.ts` | `applyClaim`, `ignoreClaim`, `updateStatus` 메서드 구현 |
| `factcheck.repository.ts` | `updateClaimStatus` 메서드 추가 |
| `factcheck-response.dto.ts` | `ClaimStatusUpdateResponse` 타입 추가 |

#### 3. MCP 모듈 수정
| 파일 | 변경 내용 |
|------|-----------|
| `mcp.service.ts` | JSON-RPC 2.0 요청/응답 처리 로직 구현 |
| `mcp.types.ts` | `JsonRpcResponse` 타입 정의 추가 |

## ✅ 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?
- [x] (필요 시) 관련 문서나 API 명세서를 업데이트했나요?

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요? (변경 없음)
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)

### 1. E2E 테스트 실행
```bash
pnpm test:e2e
```
- `factcheck-claim-status.e2e-spec.ts`: Apply/Ignore 시나리오 검증

### 2. API 수동 테스트 (Postman)

#### 게스트 토큰 발급
```bash
curl -X POST http://localhost:3000/auth/guest
```

#### Claim 승인 (Apply)
```bash
curl -X PATCH http://localhost:3000/factcheck/{factCheckId}/claims/{claimId}/apply \
  -H "Authorization: Bearer {token}"
```
**응답**: `{ "id": "claim-id", "status": "applied" }`

#### Claim 무시 (Ignore)
```bash
curl -X PATCH http://localhost:3000/factcheck/{factCheckId}/claims/{claimId}/ignore \
  -H "Authorization: Bearer {token}"
```
**응답**: `{ "id": "claim-id", "status": "ignored" }`

## ⚠️ 특이사항 (Notes)
- **DB 마이그레이션 필요**: `Sentence.id` 타입 변경으로 인해 기존 데이터가 있는 경우 마이그레이션 주의
- **게스트 No-op**: 게스트 사용자의 요청은 DB에 저장되지 않으며, 클라이언트 로직 통일을 위해 성공 응답만 반환
