### PR TITLE
test: 미테스트 항목 테스트 (#23)

### DIFF
--- a/src/api-keys/api-keys.integration.spec.ts
+++ b/src/api-keys/api-keys.integration.spec.ts
@@ -1,0 +1,347 @@
+import { ForbiddenException, NotFoundException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Test, type TestingModule } from "@nestjs/testing";
+import type { AuthenticatedUser } from "../auth/types/auth.types";
+import { ERROR_CODES } from "../common/constants/error-codes";
+import { RedisService } from "../redis/redis.service";
+import { ApiKeysController } from "./api-keys.controller";
+import { ApiKeysService } from "./api-keys.service";
+import { API_KEY_CACHE_TTL, API_KEY_PREFIX, DEFAULT_MAX_API_KEYS } from "./constants";
+import { ApiKeysRepository } from "./repositories/api-keys.repository";
+
+interface MockApiKeyRecord {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  keyHash: string;
+  userId: string;
+  createdAt: Date;
+}
+
+const createApiKeyRecord = (overrides?: Partial<MockApiKeyRecord>): MockApiKeyRecord => ({
+  id: "key-1",
+  name: "테스트 API 키",
+  keyPrefix: "rtf_abcd1234",
+  keyHash: "hashed",
+  userId: "user-123",
+  createdAt: new Date("2026-01-01"),
+  ...overrides,
+});
+
+const createUser = (overrides?: Partial<AuthenticatedUser>): AuthenticatedUser => ({
+  userId: "user-123",
+  email: "test@example.com",
+  isGuest: false as const,
+  ...overrides,
+});
+
+describe("ApiKeysController + ApiKeysService Integration", () => {
+  let controller: ApiKeysController;
+  let service: ApiKeysService;
+
+  const mockApiKeysRepository = {
+    create: jest.fn(),
+    findByUserId: jest.fn(),
+    countByUserId: jest.fn(),
+    findByPrefix: jest.fn(),
+    findById: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const mockRedisService = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ApiKeysController],
+      providers: [
+        ApiKeysService,
+        { provide: ApiKeysRepository, useValue: mockApiKeysRepository },
+        { provide: RedisService, useValue: mockRedisService },
+        { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue("test-secret") } },
+      ],
+    }).compile();
+
+    controller = module.get<ApiKeysController>(ApiKeysController);
+    service = module.get<ApiKeysService>(ApiKeysService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("create", () => {
+    const user = createUser();
+    const dto = { name: "새 API 키" };
+
+    it("API 키를 생성하고 secretKey를 포함한 결과를 반환해야 한다", async () => {
+      mockApiKeysRepository.countByUserId.mockResolvedValue(0);
+      mockApiKeysRepository.create.mockResolvedValue(createApiKeyRecord({ name: dto.name }));
+
+      const result = await controller.create(user, dto);
+
+      expect(result.id).toBe("key-1");
+      expect(result.name).toBe(dto.name);
+      expect(typeof result.prefix).toBe("string");
+      expect(result.secretKey).toMatch(new RegExp(`^${API_KEY_PREFIX}`));
+      expect(result.createdAt).toBeInstanceOf(Date);
+    });
+
+    it("repository.create에 userId와 해시된 키를 전달해야 한다", async () => {
+      mockApiKeysRepository.countByUserId.mockResolvedValue(0);
+      mockApiKeysRepository.create.mockResolvedValue(createApiKeyRecord({ name: dto.name }));
+
+      await controller.create(user, dto);
+
+      expect(mockApiKeysRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: user.userId,
+          name: dto.name,
+        }),
+      );
+    });
+
+    it("한도 초과 시 ForbiddenException을 던져야 한다", async () => {
+      mockApiKeysRepository.countByUserId.mockResolvedValue(DEFAULT_MAX_API_KEYS);
+
+      await expect(controller.create(user, dto)).rejects.toThrow(
+        new ForbiddenException(ERROR_CODES.API_KEY_LIMIT_EXCEEDED),
+      );
+    });
+
+    it("한도 미만이면 정상적으로 생성해야 한다", async () => {
+      mockApiKeysRepository.countByUserId.mockResolvedValue(DEFAULT_MAX_API_KEYS - 1);
+      mockApiKeysRepository.create.mockResolvedValue(createApiKeyRecord({ name: dto.name }));
+
+      const result = await controller.create(user, dto);
+
+      expect(result.secretKey).toBeDefined();
+      expect(mockApiKeysRepository.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("findAll", () => {
+    const user = createUser();
+
+    it("사용자의 API 키 목록을 변환하여 반환해야 한다", async () => {
+      const now = new Date();
+      mockApiKeysRepository.findByUserId.mockResolvedValue([
+        createApiKeyRecord({
+          id: "key-1",
+          name: "키 1",
+          keyPrefix: "rtf_aaaa1111",
+          createdAt: now,
+        }),
+        createApiKeyRecord({
+          id: "key-2",
+          name: "키 2",
+          keyPrefix: "rtf_bbbb2222",
+          createdAt: now,
+        }),
+      ]);
+
+      const result = await controller.findAll(user);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        id: "key-1",
+        name: "키 1",
+        prefix: "rtf_aaaa1111",
+        createdAt: now,
+      });
+      expect(result[1]).toEqual({
+        id: "key-2",
+        name: "키 2",
+        prefix: "rtf_bbbb2222",
+        createdAt: now,
+      });
+    });
+
+    it("keyHash를 응답에 포함하지 않아야 한다", async () => {
+      mockApiKeysRepository.findByUserId.mockResolvedValue([
+        createApiKeyRecord({ keyHash: "should_not_appear" }),
+      ]);
+
+      const result = await controller.findAll(user);
+
+      expect(result[0]).not.toHaveProperty("keyHash");
+      expect(result[0]).not.toHaveProperty("userId");
+    });
+
+    it("키가 없으면 빈 배열을 반환해야 한다", async () => {
+      mockApiKeysRepository.findByUserId.mockResolvedValue([]);
+
+      const result = await controller.findAll(user);
+
+      expect(result).toEqual([]);
+    });
+
+    it("repository.findByUserId를 올바른 userId로 호출해야 한다", async () => {
+      mockApiKeysRepository.findByUserId.mockResolvedValue([]);
+
+      await controller.findAll(user);
+
+      expect(mockApiKeysRepository.findByUserId).toHaveBeenCalledWith(user.userId);
+    });
+  });
+
+  describe("remove", () => {
+    const user = createUser();
+    const keyId = "key-1";
+
+    it("키를 삭제하고 { success: true }를 반환해야 한다", async () => {
+      mockApiKeysRepository.findById.mockResolvedValue(createApiKeyRecord());
+      mockApiKeysRepository.delete.mockResolvedValue(undefined);
+      mockRedisService.del.mockResolvedValue(undefined);
+
+      const result = await controller.remove(user, keyId);
+
+      expect(result).toEqual({ success: true });
+      expect(mockApiKeysRepository.delete).toHaveBeenCalledWith(keyId);
+    });
+
+    it("삭제 시 Redis 캐시도 함께 제거해야 한다", async () => {
+      const prefix = "rtf_abcd1234";
+      mockApiKeysRepository.findById.mockResolvedValue(createApiKeyRecord({ keyPrefix: prefix }));
+      mockApiKeysRepository.delete.mockResolvedValue(undefined);
+      mockRedisService.del.mockResolvedValue(undefined);
+
+      await controller.remove(user, keyId);
+
+      expect(mockRedisService.del).toHaveBeenCalledWith(`auth:apikey:${prefix}`);
+    });
+
+    it("존재하지 않는 키면 NotFoundException을 던져야 한다", async () => {
+      mockApiKeysRepository.findById.mockResolvedValue(null);
+
+      await expect(controller.remove(user, keyId)).rejects.toThrow(
+        new NotFoundException(ERROR_CODES.API_KEY_NOT_FOUND),
+      );
+    });
+
+    it("다른 사용자의 키면 NotFoundException을 던져야 한다", async () => {
+      mockApiKeysRepository.findById.mockResolvedValue(
+        createApiKeyRecord({ userId: "other-user" }),
+      );
+
+      await expect(controller.remove(user, keyId)).rejects.toThrow(
+        new NotFoundException(ERROR_CODES.API_KEY_NOT_FOUND),
+      );
+    });
+  });
+
+  describe("verify", () => {
+    it("유효한 API 키면 { valid: true, userId }를 반환해야 한다", async () => {
+      const apiKey = "rtf_abcdef123456rest_of_key";
+      const prefix = apiKey.substring(0, 12);
+      const keyHash = service["hashKey"](apiKey);
+      mockRedisService.get.mockResolvedValue(null);
+      mockApiKeysRepository.findByPrefix.mockResolvedValue(
+        createApiKeyRecord({ keyHash, keyPrefix: prefix, userId: "user-123" }),
+      );
+      mockRedisService.set.mockResolvedValue(undefined);
+
+      const result = await controller.verify({ key: apiKey });
+
+      expect(result).toEqual({ valid: true, userId: "user-123" });
+    });
+
+    it("잘못된 접두사면 { valid: false }를 반환해야 한다", async () => {
+      const result = await controller.verify({ key: "invalid_key_format" });
+
+      expect(result).toEqual({ valid: false });
+      expect(mockApiKeysRepository.findByPrefix).not.toHaveBeenCalled();
+    });
+
+    it("DB에 키가 없으면 { valid: false }를 반환해야 한다", async () => {
+      mockRedisService.get.mockResolvedValue(null);
+      mockApiKeysRepository.findByPrefix.mockResolvedValue(null);
+      mockRedisService.set.mockResolvedValue(undefined);
+
+      const result = await controller.verify({ key: "rtf_abcdef123456rest_of_key" });
+
+      expect(result).toEqual({ valid: false });
+    });
+
+    it("해시 불일치면 { valid: false }를 반환해야 한다", async () => {
+      mockRedisService.get.mockResolvedValue(null);
+      mockApiKeysRepository.findByPrefix.mockResolvedValue(
+        createApiKeyRecord({
+          keyHash: "a".repeat(64),
+          keyPrefix: "rtf_abcdef12",
+        }),
+      );
+      mockRedisService.set.mockResolvedValue(undefined);
+
+      const result = await controller.verify({ key: "rtf_abcdef123456rest_of_key" });
+
+      expect(result).toEqual({ valid: false });
+    });
+
+    describe("캐시", () => {
+      it("Redis 캐시 히트 시 DB를 조회하지 않아야 한다", async () => {
+        const cachedResult = JSON.stringify({ valid: true, userId: "user-123" });
+        mockRedisService.get.mockResolvedValue(cachedResult);
+
+        const result = await controller.verify({ key: "rtf_abcdef123456rest_of_key" });
+
+        expect(result).toEqual({ valid: true, userId: "user-123" });
+        expect(mockApiKeysRepository.findByPrefix).not.toHaveBeenCalled();
+      });
+
+      it("검증 결과를 올바른 TTL로 캐시해야 한다", async () => {
+        const apiKey = "rtf_abcdef123456rest_of_key";
+        const prefix = apiKey.substring(0, 12);
+        const keyHash = service["hashKey"](apiKey);
+        mockRedisService.get.mockResolvedValue(null);
+        mockApiKeysRepository.findByPrefix.mockResolvedValue(
+          createApiKeyRecord({ keyHash, keyPrefix: prefix }),
+        );
+        mockRedisService.set.mockResolvedValue(undefined);
+
+        await controller.verify({ key: apiKey });
+
+        expect(mockRedisService.set).toHaveBeenCalledWith(
+          `auth:apikey:${prefix}`,
+          expect.any(String),
+          API_KEY_CACHE_TTL,
+        );
+      });
+
+      it("캐시 파싱 실패 시 캐시를 삭제하고 DB로 폴스루해야 한다", async () => {
+        const apiKey = "rtf_abcdef123456rest_of_key";
+        const prefix = apiKey.substring(0, 12);
+        const keyHash = service["hashKey"](apiKey);
+        mockRedisService.get.mockResolvedValue("invalid json{{{");
+        mockRedisService.del.mockResolvedValue(undefined);
+        mockRedisService.set.mockResolvedValue(undefined);
+        mockApiKeysRepository.findByPrefix.mockResolvedValue(
+          createApiKeyRecord({ keyHash, keyPrefix: prefix }),
+        );
+
+        const result = await controller.verify({ key: apiKey });
+
+        expect(mockRedisService.del).toHaveBeenCalledWith(`auth:apikey:${prefix}`);
+        expect(mockApiKeysRepository.findByPrefix).toHaveBeenCalledWith(prefix);
+        expect(result).toEqual({ valid: true, userId: "user-123" });
+      });
+
+      it("무효 키 검증 결과도 캐시해야 한다", async () => {
+        mockRedisService.get.mockResolvedValue(null);
+        mockApiKeysRepository.findByPrefix.mockResolvedValue(null);
+        mockRedisService.set.mockResolvedValue(undefined);
+
+        await controller.verify({ key: "rtf_abcdef123456rest_of_key" });
+
+        expect(mockRedisService.set).toHaveBeenCalledWith(
+          expect.stringContaining("auth:apikey:"),
+          JSON.stringify({ valid: false }),
+          API_KEY_CACHE_TTL,
+        );
+      });
+    });
+  });
+});

--- a/src/api-keys/api-keys.service.spec.ts
+++ b/src/api-keys/api-keys.service.spec.ts
@@ -5,6 +5,25 @@ import { ApiKeysService } from "./api-keys.service";
 import { API_KEY_CACHE_TTL, API_KEY_PREFIX, DEFAULT_MAX_API_KEYS } from "./constants";
 import { ApiKeysRepository } from "./repositories/api-keys.repository";
 
+interface MockApiKeyRecord {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  keyHash: string;
+  userId: string;
+  createdAt: Date;
+}
+
+const createApiKeyRecord = (overrides?: Partial<MockApiKeyRecord>): MockApiKeyRecord => ({
+  id: "key-id",
+  name: "My API Key",
+  keyPrefix: "rtf_abcd1234",
+  keyHash: "hashed",
+  userId: "user-123",
+  createdAt: new Date("2026-01-01"),
+  ...overrides,
+});
+
 describe("ApiKeysService", () => {
   let service: ApiKeysService;
 
@@ -95,13 +114,7 @@ describe("ApiKeysService", () => {
 
     it("API 키를 정상적으로 생성해야 한다", async () => {
       mockApiKeysRepository.countByUserId.mockResolvedValue(0);
-      mockApiKeysRepository.create.mockResolvedValue({
-        id: "key-id",
-        name: "My API Key",
-        keyPrefix: "rtf_abcd1234",
-        keyHash: "hashed",
-        createdAt: new Date("2026-01-01"),
-      });
+      mockApiKeysRepository.create.mockResolvedValue(createApiKeyRecord());
 
       const result = await service.createApiKey(userId, createDto);
 
@@ -114,13 +127,7 @@ describe("ApiKeysService", () => {
 
     it("secretKey가 rtf_ 접두사로 시작해야 한다", async () => {
       mockApiKeysRepository.countByUserId.mockResolvedValue(0);
-      mockApiKeysRepository.create.mockResolvedValue({
-        id: "key-id",
-        name: "My API Key",
-        keyPrefix: "rtf_abcd1234",
-        keyHash: "hashed",
-        createdAt: new Date(),
-      });
+      mockApiKeysRepository.create.mockResolvedValue(createApiKeyRecord());
 
       const result = await service.createApiKey(userId, createDto);
 
@@ -133,13 +140,7 @@ describe("ApiKeysService", () => {
       let savedKeyHash = "";
       mockApiKeysRepository.create.mockImplementation((data: { keyHash: string }) => {
         savedKeyHash = data.keyHash;
-        return Promise.resolve({
-          id: "key-id",
-          name: "My API Key",
-          keyPrefix: "rtf_abcd1234",
-          keyHash: data.keyHash,
-          createdAt: new Date(),
-        });
+        return Promise.resolve(createApiKeyRecord({ keyHash: data.keyHash }));
       });
 
       await service.createApiKey(userId, createDto);
@@ -159,11 +160,7 @@ describe("ApiKeysService", () => {
     const keyId = "key-id";
 
     it("키를 정상적으로 삭제해야 한다", async () => {
-      mockApiKeysRepository.findById.mockResolvedValue({
-        id: keyId,
-        userId,
-        keyPrefix: "rtf_abcd1234",
-      });
+      mockApiKeysRepository.findById.mockResolvedValue(createApiKeyRecord());
       mockApiKeysRepository.delete.mockResolvedValue(undefined);
       mockRedisService.del.mockResolvedValue(undefined);
 
@@ -174,11 +171,7 @@ describe("ApiKeysService", () => {
 
     it("Redis 캐시도 함께 삭제해야 한다", async () => {
       const prefix = "rtf_abcd1234";
-      mockApiKeysRepository.findById.mockResolvedValue({
-        id: keyId,
-        userId,
-        keyPrefix: prefix,
-      });
+      mockApiKeysRepository.findById.mockResolvedValue(createApiKeyRecord({ keyPrefix: prefix }));
       mockApiKeysRepository.delete.mockResolvedValue(undefined);
       mockRedisService.del.mockResolvedValue(undefined);
 
@@ -194,11 +187,8 @@ describe("ApiKeysService", () => {
     });
 
     it("다른 사용자의 키면 NotFoundException을 던져야 한다", async () => {
-      mockApiKeysRepository.findById.mockResolvedValue({
-        id: keyId,
-        userId: "other-user",
-        keyPrefix: "rtf_abcd1234",
-      });
+      const otherUserKey = createApiKeyRecord({ userId: "other-user" });
+      mockApiKeysRepository.findById.mockResolvedValue(otherUserKey);
 
       await expect(service.deleteApiKey(userId, keyId)).rejects.toThrow(NotFoundException);
     });
@@ -241,11 +231,9 @@ describe("ApiKeysService", () => {
       mockRedisService.get.mockResolvedValue("invalid json{{{");
       mockRedisService.del.mockResolvedValue(undefined);
       mockRedisService.set.mockResolvedValue(undefined);
-      mockApiKeysRepository.findByPrefix.mockResolvedValue({
-        userId: "user-123",
-        keyHash,
-        keyPrefix: prefix,
-      });
+      mockApiKeysRepository.findByPrefix.mockResolvedValue(
+        createApiKeyRecord({ keyHash, keyPrefix: prefix }),
+      );
 
       await service.verifyApiKey(apiKey);
 
@@ -266,11 +254,11 @@ describe("ApiKeysService", () => {
 
     it("해시 불일치 시 { valid: false }를 반환하고 캐시해야 한다", async () => {
       mockRedisService.get.mockResolvedValue(null);
-      mockApiKeysRepository.findByPrefix.mockResolvedValue({
-        userId: "user-123",
+      const keyWithMismatchedHash = createApiKeyRecord({
         keyHash: "completely_different_hash_value_that_does_not_match_at_all_x",
         keyPrefix: "rtf_abcdef12",
       });
+      mockApiKeysRepository.findByPrefix.mockResolvedValue(keyWithMismatchedHash);
       mockRedisService.set.mockResolvedValue(undefined);
 
       const result = await service.verifyApiKey("rtf_abcdef123456rest_of_key");
@@ -285,11 +273,9 @@ describe("ApiKeysService", () => {
       const keyHash = service["hashKey"](apiKey);
 
       mockRedisService.get.mockResolvedValue(null);
-      mockApiKeysRepository.findByPrefix.mockResolvedValue({
-        userId: "user-123",
-        keyHash,
-        keyPrefix: prefix,
-      });
+      mockApiKeysRepository.findByPrefix.mockResolvedValue(
+        createApiKeyRecord({ keyHash, keyPrefix: prefix }),
+      );
       mockRedisService.set.mockResolvedValue(undefined);
 
       const result = await service.verifyApiKey(apiKey);
@@ -303,11 +289,9 @@ describe("ApiKeysService", () => {
       const keyHash = service["hashKey"](apiKey);
 
       mockRedisService.get.mockResolvedValue(null);
-      mockApiKeysRepository.findByPrefix.mockResolvedValue({
-        userId: "user-123",
-        keyHash,
-        keyPrefix: apiKey.substring(0, 12),
-      });
+      mockApiKeysRepository.findByPrefix.mockResolvedValue(
+        createApiKeyRecord({ keyHash, keyPrefix: apiKey.substring(0, 12) }),
+      );
       mockRedisService.set.mockResolvedValue(undefined);
 
       await service.verifyApiKey(apiKey);
@@ -326,8 +310,20 @@ describe("ApiKeysService", () => {
     it("사용자의 API 키 목록을 반환해야 한다", async () => {
       const now = new Date();
       mockApiKeysRepository.findByUserId.mockResolvedValue([
-        { id: "key-1", name: "Key 1", keyPrefix: "rtf_aaaa1111", keyHash: "hash1", createdAt: now },
-        { id: "key-2", name: "Key 2", keyPrefix: "rtf_bbbb2222", keyHash: "hash2", createdAt: now },
+        createApiKeyRecord({
+          id: "key-1",
+          name: "Key 1",
+          keyPrefix: "rtf_aaaa1111",
+          keyHash: "hash1",
+          createdAt: now,
+        }),
+        createApiKeyRecord({
+          id: "key-2",
+          name: "Key 2",
+          keyPrefix: "rtf_bbbb2222",
+          keyHash: "hash2",
+          createdAt: now,
+        }),
       ]);
 
       const result = await service.listApiKeys(userId);
@@ -343,13 +339,12 @@ describe("ApiKeysService", () => {
 
     it("keyHash를 응답에 포함하지 않아야 한다", async () => {
       mockApiKeysRepository.findByUserId.mockResolvedValue([
-        {
+        createApiKeyRecord({
           id: "key-1",
           name: "Key 1",
           keyPrefix: "rtf_aaaa1111",
           keyHash: "should_not_appear",
-          createdAt: new Date(),
-        },
+        }),
       ]);
 
       const result = await service.listApiKeys(userId);

--- a/src/api-keys/api-keys.service.spec.ts
+++ b/src/api-keys/api-keys.service.spec.ts
@@ -1,20 +1,12 @@
 import { ForbiddenException, NotFoundException } from "@nestjs/common";
 import { Test, type TestingModule } from "@nestjs/testing";
+import type { ApiKey } from "@prisma/client";
 import { RedisService } from "../redis/redis.service";
 import { ApiKeysService } from "./api-keys.service";
 import { API_KEY_CACHE_TTL, API_KEY_PREFIX, DEFAULT_MAX_API_KEYS } from "./constants";
 import { ApiKeysRepository } from "./repositories/api-keys.repository";
 
-interface MockApiKeyRecord {
-  id: string;
-  name: string;
-  keyPrefix: string;
-  keyHash: string;
-  userId: string;
-  createdAt: Date;
-}
-
-const createApiKeyRecord = (overrides?: Partial<MockApiKeyRecord>): MockApiKeyRecord => ({
+const createApiKeyRecord = (overrides?: Partial<ApiKey>): ApiKey => ({
   id: "key-id",
   name: "My API Key",
   keyPrefix: "rtf_abcd1234",

--- a/src/api-keys/api-keys.service.spec.ts
+++ b/src/api-keys/api-keys.service.spec.ts
@@ -1,0 +1,368 @@
+import { ForbiddenException, NotFoundException } from "@nestjs/common";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { RedisService } from "../redis/redis.service";
+import { ApiKeysService } from "./api-keys.service";
+import { API_KEY_CACHE_TTL, API_KEY_PREFIX, DEFAULT_MAX_API_KEYS } from "./constants";
+import { ApiKeysRepository } from "./repositories/api-keys.repository";
+
+describe("ApiKeysService", () => {
+  let service: ApiKeysService;
+
+  const mockApiKeysRepository = {
+    create: jest.fn(),
+    findByUserId: jest.fn(),
+    countByUserId: jest.fn(),
+    findByPrefix: jest.fn(),
+    findById: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const mockRedisService = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApiKeysService,
+        { provide: ApiKeysRepository, useValue: mockApiKeysRepository },
+        { provide: RedisService, useValue: mockRedisService },
+      ],
+    }).compile();
+
+    service = module.get<ApiKeysService>(ApiKeysService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("hashKey", () => {
+    it("동일 입력에 대해 동일 해시를 반환해야 한다", () => {
+      const key = "rtf_test_key_123";
+      const hash1 = service["hashKey"](key);
+      const hash2 = service["hashKey"](key);
+
+      expect(hash1).toBe(hash2);
+    });
+
+    it("다른 입력에 대해 다른 해시를 반환해야 한다", () => {
+      const hash1 = service["hashKey"]("rtf_key_aaa");
+      const hash2 = service["hashKey"]("rtf_key_bbb");
+
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it("SHA256 hex 형식(64자)을 반환해야 한다", () => {
+      const hash = service["hashKey"]("rtf_test_key");
+
+      expect(hash).toHaveLength(64);
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+
+  describe("verifyHash", () => {
+    it("올바른 키와 해시 쌍이면 true를 반환해야 한다", () => {
+      const key = "rtf_correct_key";
+      const hash = service["hashKey"](key);
+
+      const result = service["verifyHash"](key, hash);
+
+      expect(result).toBe(true);
+    });
+
+    it("잘못된 키면 false를 반환해야 한다", () => {
+      const correctKey = "rtf_correct_key";
+      const hash = service["hashKey"](correctKey);
+
+      const result = service["verifyHash"]("rtf_wrong_key", hash);
+
+      expect(result).toBe(false);
+    });
+
+    it("길이가 다른 해시면 false를 반환해야 한다", () => {
+      const result = service["verifyHash"]("rtf_key", "short_hash");
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("createApiKey", () => {
+    const userId = "user-123";
+    const createDto = { name: "My API Key" };
+
+    it("API 키를 정상적으로 생성해야 한다", async () => {
+      mockApiKeysRepository.countByUserId.mockResolvedValue(0);
+      mockApiKeysRepository.create.mockResolvedValue({
+        id: "key-id",
+        name: "My API Key",
+        keyPrefix: "rtf_abcd1234",
+        keyHash: "hashed",
+        createdAt: new Date("2026-01-01"),
+      });
+
+      const result = await service.createApiKey(userId, createDto);
+
+      expect(result).toHaveProperty("id");
+      expect(result).toHaveProperty("name", "My API Key");
+      expect(result).toHaveProperty("prefix");
+      expect(result).toHaveProperty("secretKey");
+      expect(result).toHaveProperty("createdAt");
+    });
+
+    it("secretKey가 rtf_ 접두사로 시작해야 한다", async () => {
+      mockApiKeysRepository.countByUserId.mockResolvedValue(0);
+      mockApiKeysRepository.create.mockResolvedValue({
+        id: "key-id",
+        name: "My API Key",
+        keyPrefix: "rtf_abcd1234",
+        keyHash: "hashed",
+        createdAt: new Date(),
+      });
+
+      const result = await service.createApiKey(userId, createDto);
+
+      expect(result.secretKey).toMatch(new RegExp(`^${API_KEY_PREFIX}`));
+    });
+
+    it("keyHash를 SHA256으로 해싱하여 저장해야 한다", async () => {
+      mockApiKeysRepository.countByUserId.mockResolvedValue(0);
+
+      let savedKeyHash = "";
+      mockApiKeysRepository.create.mockImplementation((data: { keyHash: string }) => {
+        savedKeyHash = data.keyHash;
+        return Promise.resolve({
+          id: "key-id",
+          name: "My API Key",
+          keyPrefix: "rtf_abcd1234",
+          keyHash: data.keyHash,
+          createdAt: new Date(),
+        });
+      });
+
+      await service.createApiKey(userId, createDto);
+
+      expect(savedKeyHash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("한도 초과 시 ForbiddenException을 던져야 한다", async () => {
+      mockApiKeysRepository.countByUserId.mockResolvedValue(DEFAULT_MAX_API_KEYS);
+
+      await expect(service.createApiKey(userId, createDto)).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe("deleteApiKey", () => {
+    const userId = "user-123";
+    const keyId = "key-id";
+
+    it("키를 정상적으로 삭제해야 한다", async () => {
+      mockApiKeysRepository.findById.mockResolvedValue({
+        id: keyId,
+        userId,
+        keyPrefix: "rtf_abcd1234",
+      });
+      mockApiKeysRepository.delete.mockResolvedValue(undefined);
+      mockRedisService.del.mockResolvedValue(undefined);
+
+      const result = await service.deleteApiKey(userId, keyId);
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it("Redis 캐시도 함께 삭제해야 한다", async () => {
+      const prefix = "rtf_abcd1234";
+      mockApiKeysRepository.findById.mockResolvedValue({
+        id: keyId,
+        userId,
+        keyPrefix: prefix,
+      });
+      mockApiKeysRepository.delete.mockResolvedValue(undefined);
+      mockRedisService.del.mockResolvedValue(undefined);
+
+      await service.deleteApiKey(userId, keyId);
+
+      expect(mockRedisService.del).toHaveBeenCalledWith(`auth:apikey:${prefix}`);
+    });
+
+    it("존재하지 않는 키면 NotFoundException을 던져야 한다", async () => {
+      mockApiKeysRepository.findById.mockResolvedValue(null);
+
+      await expect(service.deleteApiKey(userId, keyId)).rejects.toThrow(NotFoundException);
+    });
+
+    it("다른 사용자의 키면 NotFoundException을 던져야 한다", async () => {
+      mockApiKeysRepository.findById.mockResolvedValue({
+        id: keyId,
+        userId: "other-user",
+        keyPrefix: "rtf_abcd1234",
+      });
+
+      await expect(service.deleteApiKey(userId, keyId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("verifyApiKey", () => {
+    it("빈 키면 { valid: false }를 반환해야 한다", async () => {
+      const result = await service.verifyApiKey("");
+
+      expect(result).toEqual({ valid: false });
+    });
+
+    it("null이면 { valid: false }를 반환해야 한다", async () => {
+      const result = await service.verifyApiKey(null as unknown as string);
+
+      expect(result).toEqual({ valid: false });
+    });
+
+    it("rtf_ 접두사가 없으면 { valid: false }를 반환해야 한다", async () => {
+      const result = await service.verifyApiKey("invalid_key_format");
+
+      expect(result).toEqual({ valid: false });
+    });
+
+    it("Redis 캐시 히트 시 DB를 조회하지 않아야 한다", async () => {
+      const cachedResult = JSON.stringify({ valid: true, userId: "user-123" });
+      mockRedisService.get.mockResolvedValue(cachedResult);
+
+      const result = await service.verifyApiKey("rtf_abcdef123456rest_of_key");
+
+      expect(result).toEqual({ valid: true, userId: "user-123" });
+      expect(mockApiKeysRepository.findByPrefix).not.toHaveBeenCalled();
+    });
+
+    it("캐시 파싱 실패 시 캐시를 삭제하고 DB로 폴스루해야 한다", async () => {
+      const apiKey = "rtf_abcdef123456rest_of_key";
+      const prefix = apiKey.substring(0, 12);
+      const keyHash = service["hashKey"](apiKey);
+
+      mockRedisService.get.mockResolvedValue("invalid json{{{");
+      mockRedisService.del.mockResolvedValue(undefined);
+      mockRedisService.set.mockResolvedValue(undefined);
+      mockApiKeysRepository.findByPrefix.mockResolvedValue({
+        userId: "user-123",
+        keyHash,
+        keyPrefix: prefix,
+      });
+
+      await service.verifyApiKey(apiKey);
+
+      expect(mockRedisService.del).toHaveBeenCalled();
+      expect(mockApiKeysRepository.findByPrefix).toHaveBeenCalledWith(prefix);
+    });
+
+    it("DB에 키가 없으면 { valid: false }를 반환하고 캐시해야 한다", async () => {
+      mockRedisService.get.mockResolvedValue(null);
+      mockApiKeysRepository.findByPrefix.mockResolvedValue(null);
+      mockRedisService.set.mockResolvedValue(undefined);
+
+      const result = await service.verifyApiKey("rtf_abcdef123456rest_of_key");
+
+      expect(result).toEqual({ valid: false });
+      expect(mockRedisService.set).toHaveBeenCalled();
+    });
+
+    it("해시 불일치 시 { valid: false }를 반환하고 캐시해야 한다", async () => {
+      mockRedisService.get.mockResolvedValue(null);
+      mockApiKeysRepository.findByPrefix.mockResolvedValue({
+        userId: "user-123",
+        keyHash: "completely_different_hash_value_that_does_not_match_at_all_x",
+        keyPrefix: "rtf_abcdef12",
+      });
+      mockRedisService.set.mockResolvedValue(undefined);
+
+      const result = await service.verifyApiKey("rtf_abcdef123456rest_of_key");
+
+      expect(result).toEqual({ valid: false });
+      expect(mockRedisService.set).toHaveBeenCalled();
+    });
+
+    it("해시 일치 시 { valid: true, userId }를 반환하고 캐시해야 한다", async () => {
+      const apiKey = "rtf_abcdef123456rest_of_key";
+      const prefix = apiKey.substring(0, 12);
+      const keyHash = service["hashKey"](apiKey);
+
+      mockRedisService.get.mockResolvedValue(null);
+      mockApiKeysRepository.findByPrefix.mockResolvedValue({
+        userId: "user-123",
+        keyHash,
+        keyPrefix: prefix,
+      });
+      mockRedisService.set.mockResolvedValue(undefined);
+
+      const result = await service.verifyApiKey(apiKey);
+
+      expect(result).toEqual({ valid: true, userId: "user-123" });
+      expect(mockRedisService.set).toHaveBeenCalled();
+    });
+
+    it("캐시 TTL을 300초(300_000ms)로 설정해야 한다", async () => {
+      const apiKey = "rtf_abcdef123456rest_of_key";
+      const keyHash = service["hashKey"](apiKey);
+
+      mockRedisService.get.mockResolvedValue(null);
+      mockApiKeysRepository.findByPrefix.mockResolvedValue({
+        userId: "user-123",
+        keyHash,
+        keyPrefix: apiKey.substring(0, 12),
+      });
+      mockRedisService.set.mockResolvedValue(undefined);
+
+      await service.verifyApiKey(apiKey);
+
+      expect(mockRedisService.set).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        API_KEY_CACHE_TTL,
+      );
+    });
+  });
+
+  describe("listApiKeys", () => {
+    const userId = "user-123";
+
+    it("사용자의 API 키 목록을 반환해야 한다", async () => {
+      const now = new Date();
+      mockApiKeysRepository.findByUserId.mockResolvedValue([
+        { id: "key-1", name: "Key 1", keyPrefix: "rtf_aaaa1111", keyHash: "hash1", createdAt: now },
+        { id: "key-2", name: "Key 2", keyPrefix: "rtf_bbbb2222", keyHash: "hash2", createdAt: now },
+      ]);
+
+      const result = await service.listApiKeys(userId);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        id: "key-1",
+        name: "Key 1",
+        prefix: "rtf_aaaa1111",
+        createdAt: now,
+      });
+    });
+
+    it("keyHash를 응답에 포함하지 않아야 한다", async () => {
+      mockApiKeysRepository.findByUserId.mockResolvedValue([
+        {
+          id: "key-1",
+          name: "Key 1",
+          keyPrefix: "rtf_aaaa1111",
+          keyHash: "should_not_appear",
+          createdAt: new Date(),
+        },
+      ]);
+
+      const result = await service.listApiKeys(userId);
+
+      expect(result[0]).not.toHaveProperty("keyHash");
+    });
+
+    it("키가 없으면 빈 배열을 반환해야 한다", async () => {
+      mockApiKeysRepository.findByUserId.mockResolvedValue([]);
+
+      const result = await service.listApiKeys(userId);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -72,10 +72,6 @@ describe("AuthController", () => {
     controller = module.get<AuthController>(AuthController);
   });
 
-  it("정의되어 있어야 합니다", () => {
-    expect(controller).toBeDefined();
-  });
-
   describe("googleAuthCallback", () => {
     const user = {
       email: "test@example.com",

--- a/src/auth/auth.integration.spec.ts
+++ b/src/auth/auth.integration.spec.ts
@@ -1,0 +1,427 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { JwtService } from "@nestjs/jwt";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ERROR_CODES } from "../common/constants/error-codes";
+import { PrismaService } from "../prisma/prisma.service";
+import { RedisService } from "../redis/redis.service";
+import { AuthController } from "./auth.controller";
+import { AuthService } from "./auth.service";
+import { GUEST_CONFIG, REFRESH_TOKEN_TTL_MS } from "./constants";
+import { GuestRepository } from "./repositories/guest.repository";
+import type {
+  AuthenticatedUser,
+  GoogleProfile,
+  GuestInfo,
+  GuestUser,
+  LogoutResponse,
+  RedirectResponse,
+  RequestWithUser,
+  TokenResponse,
+} from "./types/auth.types";
+
+jest.mock("uuid", () => ({
+  v4: () => "mock-uuid",
+}));
+
+const createUser = (overrides?: Partial<{ id: string; email: string; name: string }>) => ({
+  id: "user-123",
+  email: "test@example.com",
+  name: "테스트 사용자",
+  ...overrides,
+});
+
+const createGuestInfo = (overrides?: Partial<GuestInfo>): GuestInfo => ({
+  remainingUses: GUEST_CONFIG.INITIAL_USES,
+  createdAt: 1700000000000,
+  ...overrides,
+});
+
+const createTokenResponse = (): TokenResponse => ({
+  cookie: jest.fn(),
+  json: jest.fn(),
+});
+
+const createRequestWithCookies = (refreshToken?: string): RequestWithUser =>
+  ({
+    cookies: refreshToken !== undefined ? { refreshToken } : {},
+  }) as unknown as RequestWithUser;
+
+const createRequestWithUser = (user: AuthenticatedUser | GuestUser): RequestWithUser =>
+  ({ user }) as unknown as RequestWithUser;
+
+describe("Auth Integration (Controller + Service)", () => {
+  let controller: AuthController;
+
+  const mockPrismaService = {
+    user: {
+      upsert: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  };
+
+  const mockJwtService = {
+    sign: jest.fn(),
+    verify: jest.fn(),
+  };
+
+  const mockConfigService = {
+    getOrThrow: jest.fn((key: string) => {
+      const config: Record<string, string> = {
+        FRONTEND_URL: "http://localhost:5173",
+        JWT_SECRET: "test-jwt-secret",
+        JWT_REFRESH_SECRET: "test-jwt-refresh-secret",
+      };
+      return config[key] ?? null;
+    }),
+  };
+
+  const mockGuestRepository = {
+    getGuestInfo: jest.fn(),
+    setGuestInfo: jest.fn(),
+  };
+
+  const mockRedisService = {
+    set: jest.fn(),
+    get: jest.fn(),
+    del: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: JwtService, useValue: mockJwtService },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: GuestRepository, useValue: mockGuestRepository },
+        { provide: RedisService, useValue: mockRedisService },
+      ],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("googleAuthCallback", () => {
+    const mockGoogleProfile: GoogleProfile = {
+      email: "test@example.com",
+      name: "테스트 사용자",
+      provider: "google",
+      providerId: "google-123",
+    };
+
+    it("OAuth 로그인 성공 시 인증 코드와 함께 프론트엔드로 리다이렉트해야 한다", async () => {
+      const mockRes: RedirectResponse = { redirect: jest.fn() };
+      mockPrismaService.user.upsert.mockResolvedValue(createUser());
+      mockRedisService.set.mockResolvedValue(undefined);
+
+      await controller.googleAuthCallback(mockGoogleProfile, mockRes);
+
+      expect(mockPrismaService.user.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { email: mockGoogleProfile.email },
+        }),
+      );
+      expect(mockRedisService.set).toHaveBeenCalledWith("mock-uuid", "user-123", 60000);
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        "http://localhost:5173/auth/callback?code=mock-uuid",
+      );
+    });
+
+    it("OAuth 로그인 실패 시 에러 페이지로 리다이렉트해야 한다", async () => {
+      const mockRes: RedirectResponse = { redirect: jest.fn() };
+      mockPrismaService.user.upsert.mockRejectedValue(new Error("DB error"));
+
+      await controller.googleAuthCallback(mockGoogleProfile, mockRes);
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        "http://localhost:5173/login?error=oauth_failed",
+      );
+    });
+  });
+
+  describe("exchangeToken", () => {
+    it("유효한 코드로 요청하면 액세스 토큰을 반환하고 리프레시 토큰을 쿠키에 설정해야 한다", async () => {
+      const user = createUser();
+      const tokenResponse = createTokenResponse();
+      mockRedisService.get.mockResolvedValue(user.id);
+      mockPrismaService.user.findUnique.mockResolvedValue(user);
+      mockJwtService.sign
+        .mockReturnValueOnce("generated-access-token")
+        .mockReturnValueOnce("generated-refresh-token");
+
+      await controller.exchangeToken("valid-code", tokenResponse);
+
+      expect(mockRedisService.get).toHaveBeenCalledWith("valid-code");
+      expect(mockRedisService.del).toHaveBeenCalledWith("valid-code");
+      expect(mockPrismaService.user.findUnique).toHaveBeenCalledWith({ where: { id: user.id } });
+      expect(mockRedisService.set).toHaveBeenCalledWith(
+        `rt:${user.id}`,
+        "generated-refresh-token",
+        REFRESH_TOKEN_TTL_MS,
+      );
+      expect(tokenResponse.cookie).toHaveBeenCalledWith(
+        "refreshToken",
+        "generated-refresh-token",
+        expect.objectContaining({
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          maxAge: REFRESH_TOKEN_TTL_MS,
+        }),
+      );
+      expect(tokenResponse.json).toHaveBeenCalledWith({
+        accessToken: "generated-access-token",
+      });
+    });
+
+    it("Redis에 코드가 없으면 INVALID_AUTH_CODE UnauthorizedException을 던져야 한다", async () => {
+      const tokenResponse = createTokenResponse();
+      mockRedisService.get.mockResolvedValue(null);
+
+      await expect(controller.exchangeToken("invalid-code", tokenResponse)).rejects.toThrow(
+        new UnauthorizedException(ERROR_CODES.INVALID_AUTH_CODE),
+      );
+    });
+
+    it("코드에 대응하는 사용자가 없으면 USER_NOT_FOUND UnauthorizedException을 던져야 한다", async () => {
+      const tokenResponse = createTokenResponse();
+      mockRedisService.get.mockResolvedValue("nonexistent-user-id");
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+
+      await expect(controller.exchangeToken("valid-code", tokenResponse)).rejects.toThrow(
+        new UnauthorizedException(ERROR_CODES.USER_NOT_FOUND),
+      );
+    });
+  });
+
+  describe("refresh", () => {
+    it("유효한 리프레시 토큰이면 새 토큰 쌍을 발급해야 한다", async () => {
+      const user = createUser();
+      const tokenResponse = createTokenResponse();
+      const req = createRequestWithCookies("valid-refresh-token");
+      mockJwtService.verify.mockReturnValue({
+        id: user.id,
+        email: user.email,
+        jti: "jti-123",
+      });
+      mockRedisService.get.mockResolvedValue("valid-refresh-token");
+      mockPrismaService.user.findUnique.mockResolvedValue(user);
+      mockJwtService.sign
+        .mockReturnValueOnce("new-access-token")
+        .mockReturnValueOnce("new-refresh-token");
+
+      await controller.refresh(req, tokenResponse);
+
+      expect(mockJwtService.verify).toHaveBeenCalledWith("valid-refresh-token", {
+        secret: "test-jwt-refresh-secret",
+      });
+      expect(mockRedisService.get).toHaveBeenCalledWith(`rt:${user.id}`);
+      expect(mockRedisService.set).toHaveBeenCalledWith(
+        `rt:${user.id}`,
+        "new-refresh-token",
+        REFRESH_TOKEN_TTL_MS,
+      );
+      expect(tokenResponse.cookie).toHaveBeenCalledWith(
+        "refreshToken",
+        "new-refresh-token",
+        expect.objectContaining({
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          maxAge: REFRESH_TOKEN_TTL_MS,
+        }),
+      );
+      expect(tokenResponse.json).toHaveBeenCalledWith({ accessToken: "new-access-token" });
+    });
+
+    it("쿠키에 리프레시 토큰이 없으면 INVALID_REFRESH_TOKEN UnauthorizedException을 던져야 한다", async () => {
+      const tokenResponse = createTokenResponse();
+      const req = createRequestWithCookies();
+
+      await expect(controller.refresh(req, tokenResponse)).rejects.toThrow(
+        new UnauthorizedException(ERROR_CODES.INVALID_REFRESH_TOKEN),
+      );
+    });
+
+    it("JWT 검증에 실패하면 INVALID_REFRESH_TOKEN UnauthorizedException을 던져야 한다", async () => {
+      const tokenResponse = createTokenResponse();
+      const req = createRequestWithCookies("expired-token");
+      mockJwtService.verify.mockImplementation(() => {
+        throw new Error("jwt expired");
+      });
+
+      await expect(controller.refresh(req, tokenResponse)).rejects.toThrow(
+        new UnauthorizedException(ERROR_CODES.INVALID_REFRESH_TOKEN),
+      );
+    });
+
+    it("Redis에 저장된 토큰과 불일치하면 INVALID_REFRESH_TOKEN UnauthorizedException을 던져야 한다", async () => {
+      const tokenResponse = createTokenResponse();
+      const req = createRequestWithCookies("stolen-token");
+      mockJwtService.verify.mockReturnValue({
+        id: "user-123",
+        email: "test@example.com",
+        jti: "jti-123",
+      });
+      mockRedisService.get.mockResolvedValue("different-stored-token");
+
+      await expect(controller.refresh(req, tokenResponse)).rejects.toThrow(
+        new UnauthorizedException(ERROR_CODES.INVALID_REFRESH_TOKEN),
+      );
+    });
+
+    it("토큰은 유효하지만 사용자가 삭제되었으면 INVALID_REFRESH_TOKEN UnauthorizedException을 던져야 한다", async () => {
+      const tokenResponse = createTokenResponse();
+      const req = createRequestWithCookies("valid-refresh-token");
+      mockJwtService.verify.mockReturnValue({
+        id: "deleted-user",
+        email: "deleted@example.com",
+        jti: "jti-123",
+      });
+      mockRedisService.get.mockResolvedValue("valid-refresh-token");
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+
+      await expect(controller.refresh(req, tokenResponse)).rejects.toThrow(
+        new UnauthorizedException(ERROR_CODES.INVALID_REFRESH_TOKEN),
+      );
+    });
+  });
+
+  describe("guest", () => {
+    it("첫 방문 게스트는 새 게스트 정보를 생성하고 토큰을 발급해야 한다", async () => {
+      mockGuestRepository.getGuestInfo.mockResolvedValue(null);
+      mockGuestRepository.setGuestInfo.mockResolvedValue(undefined);
+      mockJwtService.sign.mockReturnValue("guest-access-token");
+
+      const result = await controller.guest(undefined, "192.168.1.1");
+
+      expect(mockGuestRepository.getGuestInfo).toHaveBeenCalledWith("192.168.1.1");
+      expect(mockGuestRepository.setGuestInfo).toHaveBeenCalledTimes(1);
+      const setGuestArg = mockGuestRepository.setGuestInfo.mock.calls[0] as [
+        string,
+        { remainingUses: number; createdAt: number },
+      ];
+      expect(setGuestArg[0]).toBe("192.168.1.1");
+      expect(setGuestArg[1].remainingUses).toBe(GUEST_CONFIG.INITIAL_USES);
+      expect(typeof setGuestArg[1].createdAt).toBe("number");
+      expect(result).toEqual({
+        accessToken: "guest-access-token",
+        remainingUses: GUEST_CONFIG.INITIAL_USES,
+        isGuest: true,
+      });
+    });
+
+    it("재방문 게스트는 기존 정보를 반환하고 새로 생성하지 않아야 한다", async () => {
+      const existingGuest = createGuestInfo({ remainingUses: 1 });
+      mockGuestRepository.getGuestInfo.mockResolvedValue(existingGuest);
+      mockJwtService.sign.mockReturnValue("guest-access-token");
+
+      const result = await controller.guest(undefined, "192.168.1.1");
+
+      expect(mockGuestRepository.setGuestInfo).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        accessToken: "guest-access-token",
+        remainingUses: 1,
+        isGuest: true,
+      });
+    });
+
+    it("X-Forwarded-For 헤더가 있으면 첫 번째 IP를 사용해야 한다", async () => {
+      mockGuestRepository.getGuestInfo.mockResolvedValue(createGuestInfo());
+      mockJwtService.sign.mockReturnValue("guest-token");
+
+      await controller.guest("10.0.0.1, 10.0.0.2, 10.0.0.3", "192.168.1.1");
+
+      expect(mockGuestRepository.getGuestInfo).toHaveBeenCalledWith("10.0.0.1");
+    });
+
+    it("X-Forwarded-For가 없으면 requestIp를 사용해야 한다", async () => {
+      mockGuestRepository.getGuestInfo.mockResolvedValue(createGuestInfo());
+      mockJwtService.sign.mockReturnValue("guest-token");
+
+      await controller.guest(undefined, "127.0.0.1");
+
+      expect(mockGuestRepository.getGuestInfo).toHaveBeenCalledWith("127.0.0.1");
+    });
+  });
+
+  describe("logout", () => {
+    it("쿠키를 삭제하고 Redis에서 리프레시 토큰을 제거해야 한다", async () => {
+      const req = createRequestWithUser({
+        userId: "user-123",
+        email: "test@example.com",
+        isGuest: false as const,
+      });
+      const logoutResponse: LogoutResponse = {
+        clearCookie: jest.fn(),
+        json: jest.fn(),
+      };
+
+      await controller.logout(req, logoutResponse);
+
+      expect(logoutResponse.clearCookie).toHaveBeenCalledWith("refreshToken", {
+        httpOnly: true,
+        secure: false,
+        sameSite: "lax",
+        path: "/",
+      });
+      expect(mockRedisService.del).toHaveBeenCalledWith("rt:user-123");
+      expect(logoutResponse.json).toHaveBeenCalledWith({ message: "로그아웃 되었습니다." });
+    });
+  });
+
+  describe("me", () => {
+    it("게스트 사용자면 게스트 정보를 반환해야 한다", async () => {
+      const req = createRequestWithUser({ isGuest: true as const, ip: "192.168.1.1" });
+      mockGuestRepository.getGuestInfo.mockResolvedValue(createGuestInfo({ remainingUses: 2 }));
+
+      const result = await controller.me(req);
+
+      expect(mockGuestRepository.getGuestInfo).toHaveBeenCalledWith("192.168.1.1");
+      expect(result).toEqual({
+        isGuest: true,
+        remainingUses: 2,
+      });
+    });
+
+    it("게스트 첫 방문이면 새 게스트 정보를 생성하여 반환해야 한다", async () => {
+      const req = createRequestWithUser({ isGuest: true as const, ip: "10.0.0.1" });
+      mockGuestRepository.getGuestInfo.mockResolvedValue(null);
+
+      const result = await controller.me(req);
+
+      expect(mockGuestRepository.setGuestInfo).toHaveBeenCalledWith(
+        "10.0.0.1",
+        expect.objectContaining({
+          remainingUses: GUEST_CONFIG.INITIAL_USES,
+        }),
+      );
+      expect(result).toEqual({
+        isGuest: true,
+        remainingUses: GUEST_CONFIG.INITIAL_USES,
+      });
+    });
+
+    it("인증된 사용자면 사용자 정보를 반환해야 한다", async () => {
+      const req = createRequestWithUser({
+        isGuest: false as const,
+        userId: "user-123",
+        email: "test@example.com",
+      });
+
+      const result = await controller.me(req);
+
+      expect(result).toEqual({
+        isGuest: false,
+        userId: "user-123",
+        email: "test@example.com",
+      });
+    });
+  });
+});

--- a/src/auth/auth.integration.spec.ts
+++ b/src/auth/auth.integration.spec.ts
@@ -72,7 +72,12 @@ describe("Auth Integration (Controller + Service)", () => {
         JWT_SECRET: "test-jwt-secret",
         JWT_REFRESH_SECRET: "test-jwt-refresh-secret",
       };
-      return config[key] ?? null;
+      const value = config[key];
+      if (value === undefined) {
+        throw new Error(`설정 키를 찾을 수 없습니다: ${key}`);
+      }
+
+      return value;
     }),
   };
 

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -5,7 +5,7 @@ import { Test, type TestingModule } from "@nestjs/testing";
 import { PrismaService } from "../prisma/prisma.service";
 import { RedisService } from "../redis/redis.service";
 import { AuthService } from "./auth.service";
-import { REFRESH_TOKEN_TTL_MS } from "./constants";
+import { GUEST_CONFIG, REFRESH_TOKEN_TTL_MS } from "./constants";
 import { GuestRepository } from "./repositories/guest.repository";
 import type { GoogleProfile, UserJwtPayload } from "./types/auth.types";
 
@@ -194,6 +194,49 @@ describe("AuthService", () => {
 
       // when & then
       await expect(service.refreshTokens(refreshToken)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe("getOrCreateGuest", () => {
+    const ip = "192.168.1.1";
+
+    it("기존 게스트 정보가 있으면 그대로 반환해야 한다", async () => {
+      const existingGuest = { remainingUses: 2, createdAt: 1700000000000 };
+      mockGuestRepository.getGuestInfo.mockResolvedValue(existingGuest);
+
+      const result = await service.getOrCreateGuest(ip);
+
+      expect(result).toEqual(existingGuest);
+    });
+
+    it("기존 게스트 정보가 있으면 setGuestInfo를 호출하지 않아야 한다", async () => {
+      mockGuestRepository.getGuestInfo.mockResolvedValue({
+        remainingUses: 2,
+        createdAt: 1700000000000,
+      });
+
+      await service.getOrCreateGuest(ip);
+
+      expect(mockGuestRepository.setGuestInfo).not.toHaveBeenCalled();
+    });
+
+    it("게스트 정보가 없으면 새로 생성하여 저장해야 한다", async () => {
+      mockGuestRepository.getGuestInfo.mockResolvedValue(null);
+
+      const result = await service.getOrCreateGuest(ip);
+
+      expect(mockGuestRepository.setGuestInfo).toHaveBeenCalledTimes(1);
+      expect(mockGuestRepository.setGuestInfo).toHaveBeenCalledWith(ip, result);
+      expect(result.remainingUses).toBe(GUEST_CONFIG.INITIAL_USES);
+      expect(typeof result.createdAt).toBe("number");
+    });
+
+    it("새 게스트의 remainingUses가 GUEST_CONFIG.INITIAL_USES여야 한다", async () => {
+      mockGuestRepository.getGuestInfo.mockResolvedValue(null);
+
+      const result = await service.getOrCreateGuest(ip);
+
+      expect(result.remainingUses).toBe(GUEST_CONFIG.INITIAL_USES);
     });
   });
 });

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -69,10 +69,6 @@ describe("AuthService", () => {
     jest.clearAllMocks();
   });
 
-  it("정의되어 있어야 합니다", () => {
-    expect(service).toBeDefined();
-  });
-
   describe("validateOAuthLogin", () => {
     const profile: GoogleProfile = {
       email: "test@example.com",

--- a/src/auth/guards/jwt-auth.guard.spec.ts
+++ b/src/auth/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,117 @@
+import { UnauthorizedException, type ExecutionContext } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ERROR_CODES } from "../../common/constants/error-codes";
+import { IS_PUBLIC_KEY } from "../../common/decorators/public.decorator";
+import { JwtAuthGuard } from "./jwt-auth.guard";
+
+describe("JwtAuthGuard", () => {
+  let guard: JwtAuthGuard;
+
+  const mockReflector = {
+    getAllAndOverride: jest.fn(),
+  };
+
+  const createMockContext = (): ExecutionContext =>
+    ({
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      switchToHttp: () => ({
+        getRequest: () => ({}),
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [JwtAuthGuard, { provide: Reflector, useValue: mockReflector }],
+    }).compile();
+
+    guard = module.get<JwtAuthGuard>(JwtAuthGuard);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("canActivate", () => {
+    it("@Public 데코레이터가 있으면 true를 반환해야 한다", () => {
+      mockReflector.getAllAndOverride.mockReturnValue(true);
+      const context = createMockContext();
+
+      const result = guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(mockReflector.getAllAndOverride).toHaveBeenCalledWith(IS_PUBLIC_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]);
+    });
+
+    it("@Public 데코레이터가 없으면 super.canActivate를 호출해야 한다", () => {
+      mockReflector.getAllAndOverride.mockReturnValue(false);
+      const context = createMockContext();
+      const superResult = Promise.resolve(true);
+      const superCanActivate = jest
+        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(guard)), "canActivate")
+        .mockReturnValue(superResult);
+
+      const result = guard.canActivate(context);
+
+      expect(result).toBe(superResult);
+      superCanActivate.mockRestore();
+    });
+  });
+
+  describe("handleRequest", () => {
+    it("유효한 사용자가 있으면 사용자를 반환해야 한다", () => {
+      const mockUser = { id: "user-1", email: "test@test.com" };
+
+      const result = guard.handleRequest(null, mockUser, null);
+
+      expect(result).toBe(mockUser);
+    });
+
+    it("err가 존재하면 해당 에러를 던져야 한다", () => {
+      const error = new Error("some error");
+
+      expect(() => guard.handleRequest(error, null, null)).toThrow(error);
+    });
+
+    it("err와 user가 동시에 존재하면 err를 던져야 한다", () => {
+      const error = new Error("some error");
+      const mockUser = { id: "user-1", email: "test@test.com" };
+
+      expect(() => guard.handleRequest(error, mockUser, null)).toThrow(error);
+    });
+
+    it("사용자가 없고 TokenExpiredError이면 TOKEN_EXPIRED 에러를 던져야 한다", () => {
+      const tokenExpiredError = new Error("jwt expired");
+      tokenExpiredError.name = "TokenExpiredError";
+
+      expect(() => guard.handleRequest(null, null, tokenExpiredError)).toThrow(
+        new UnauthorizedException(ERROR_CODES.TOKEN_EXPIRED),
+      );
+    });
+
+    it("사용자가 없고 토큰이 유효하지 않으면 TOKEN_INVALID 에러를 던져야 한다", () => {
+      const jsonWebTokenError = new Error("invalid token");
+      jsonWebTokenError.name = "JsonWebTokenError";
+
+      expect(() => guard.handleRequest(null, null, jsonWebTokenError)).toThrow(
+        new UnauthorizedException(ERROR_CODES.TOKEN_INVALID),
+      );
+    });
+
+    it("info가 Error 인스턴스가 아니면 TOKEN_INVALID 에러를 던져야 한다", () => {
+      expect(() => guard.handleRequest(null, null, "No auth token")).toThrow(
+        new UnauthorizedException(ERROR_CODES.TOKEN_INVALID),
+      );
+    });
+
+    it("사용자가 없고 info가 없으면 TOKEN_INVALID 에러를 던져야 한다", () => {
+      expect(() => guard.handleRequest(null, null, null)).toThrow(
+        new UnauthorizedException(ERROR_CODES.TOKEN_INVALID),
+      );
+    });
+  });
+});

--- a/src/auth/guards/shared-secret.guard.spec.ts
+++ b/src/auth/guards/shared-secret.guard.spec.ts
@@ -1,0 +1,79 @@
+import { UnauthorizedException, type ExecutionContext } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { SharedSecretGuard } from "./shared-secret.guard";
+
+describe("SharedSecretGuard", () => {
+  let guard: SharedSecretGuard;
+
+  const mockConfigService = {
+    get: jest.fn(),
+  };
+
+  const createMockContext = (headers: Record<string, unknown> = {}): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ headers }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SharedSecretGuard, { provide: ConfigService, useValue: mockConfigService }],
+    }).compile();
+
+    guard = module.get<SharedSecretGuard>(SharedSecretGuard);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("INTERNAL_API_SECRET이 미설정이면 false를 반환해야 한다", () => {
+    mockConfigService.get.mockReturnValue(undefined);
+    const context = createMockContext({ "x-internal-secret": "some-value" });
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(false);
+  });
+
+  it("INTERNAL_API_SECRET이 빈 문자열이면 false를 반환해야 한다", () => {
+    mockConfigService.get.mockReturnValue("");
+    const context = createMockContext({ "x-internal-secret": "some-value" });
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(false);
+  });
+
+  it("헤더가 없으면 UnauthorizedException을 던져야 한다", () => {
+    mockConfigService.get.mockReturnValue("valid-secret");
+    const context = createMockContext({});
+
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+  });
+
+  it("헤더 값이 불일치하면 UnauthorizedException을 던져야 한다", () => {
+    mockConfigService.get.mockReturnValue("valid-secret");
+    const context = createMockContext({ "x-internal-secret": "wrong-secret" });
+
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+  });
+
+  it("헤더 값이 일치하면 true를 반환해야 한다", () => {
+    mockConfigService.get.mockReturnValue("valid-secret");
+    const context = createMockContext({ "x-internal-secret": "valid-secret" });
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it("헤더 타입이 문자열이 아니면 UnauthorizedException을 던져야 한다", () => {
+    mockConfigService.get.mockReturnValue("valid-secret");
+    const context = createMockContext({ "x-internal-secret": ["array-value"] });
+
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+  });
+});

--- a/src/auth/repositories/guest.repository.spec.ts
+++ b/src/auth/repositories/guest.repository.spec.ts
@@ -29,6 +29,10 @@ describe("GuestRepository", () => {
     repository = module.get<GuestRepository>(GuestRepository);
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe("getGuestInfo", () => {
     it("게스트 정보가 있으면 파싱하여 반환해야 한다", async () => {
       mockRedisClient.hgetall.mockResolvedValue({

--- a/src/auth/repositories/guest.repository.spec.ts
+++ b/src/auth/repositories/guest.repository.spec.ts
@@ -1,0 +1,112 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { RedisService } from "../../redis/redis.service";
+import { GUEST_CONFIG } from "../constants";
+import { GuestRepository } from "./guest.repository";
+
+jest.mock("../utils/ip-hash.util", () => ({
+  hashIp: jest.fn().mockReturnValue("hashed-ip"),
+}));
+
+describe("GuestRepository", () => {
+  let repository: GuestRepository;
+
+  const mockRedisClient = {
+    hgetall: jest.fn(),
+    hset: jest.fn(),
+    expire: jest.fn(),
+    hincrby: jest.fn(),
+  };
+
+  const mockRedisService = {
+    getClient: jest.fn().mockReturnValue(mockRedisClient),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GuestRepository, { provide: RedisService, useValue: mockRedisService }],
+    }).compile();
+
+    repository = module.get<GuestRepository>(GuestRepository);
+  });
+
+  describe("getGuestInfo", () => {
+    it("게스트 정보가 있으면 파싱하여 반환해야 한다", async () => {
+      mockRedisClient.hgetall.mockResolvedValue({
+        remainingUses: "3",
+        createdAt: "1700000000000",
+      });
+
+      const result = await repository.getGuestInfo("192.168.1.1");
+
+      expect(result).toEqual({
+        remainingUses: 3,
+        createdAt: 1700000000000,
+      });
+      expect(mockRedisClient.hgetall).toHaveBeenCalledWith("guest:hashed-ip");
+    });
+
+    it("데이터가 없으면 null을 반환해야 한다", async () => {
+      mockRedisClient.hgetall.mockResolvedValue(null);
+
+      const result = await repository.getGuestInfo("192.168.1.1");
+
+      expect(result).toBeNull();
+    });
+
+    it("빈 객체면 null을 반환해야 한다", async () => {
+      mockRedisClient.hgetall.mockResolvedValue({});
+
+      const result = await repository.getGuestInfo("192.168.1.1");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("setGuestInfo", () => {
+    const guestInfo = { remainingUses: 3, createdAt: 1700000000000 };
+
+    it("Redis Hash에 게스트 정보를 저장해야 한다", async () => {
+      await repository.setGuestInfo("192.168.1.1", guestInfo);
+
+      expect(mockRedisClient.hset).toHaveBeenCalledWith("guest:hashed-ip", {
+        remainingUses: "3",
+        createdAt: "1700000000000",
+      });
+    });
+
+    it("기본 TTL을 설정해야 한다", async () => {
+      await repository.setGuestInfo("192.168.1.1", guestInfo);
+
+      expect(mockRedisClient.expire).toHaveBeenCalledWith(
+        "guest:hashed-ip",
+        GUEST_CONFIG.TTL_SECONDS,
+      );
+    });
+
+    it("커스텀 TTL을 적용해야 한다", async () => {
+      const customTtl = 3600;
+
+      await repository.setGuestInfo("192.168.1.1", guestInfo, customTtl);
+
+      expect(mockRedisClient.expire).toHaveBeenCalledWith("guest:hashed-ip", customTtl);
+    });
+  });
+
+  describe("decrementRemainingUses", () => {
+    it("hincrby -1로 차감해야 한다", async () => {
+      mockRedisClient.hincrby.mockResolvedValue(2);
+
+      await repository.decrementRemainingUses("192.168.1.1");
+
+      expect(mockRedisClient.hincrby).toHaveBeenCalledWith("guest:hashed-ip", "remainingUses", -1);
+    });
+
+    it("차감 후 남은 값을 반환해야 한다", async () => {
+      mockRedisClient.hincrby.mockResolvedValue(2);
+
+      const result = await repository.decrementRemainingUses("192.168.1.1");
+
+      expect(result).toBe(2);
+    });
+  });
+});

--- a/src/auth/strategies/jwt.strategy.spec.ts
+++ b/src/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,75 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ERROR_CODES } from "../../common/constants/error-codes";
+import type { GuestJwtPayload, UserJwtPayload } from "../types/auth.types";
+import { JwtStrategy } from "./jwt.strategy";
+
+describe("JwtStrategy", () => {
+  let strategy: JwtStrategy;
+
+  const mockConfigService = {
+    getOrThrow: jest.fn().mockReturnValue("test-jwt-secret"),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [JwtStrategy, { provide: ConfigService, useValue: mockConfigService }],
+    }).compile();
+
+    strategy = module.get<JwtStrategy>(JwtStrategy);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("JWT_SECRET을 ConfigService에서 가져와야 한다", () => {
+    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith("JWT_SECRET");
+  });
+
+  describe("validate", () => {
+    it("사용자 토큰이면 userId, email, isGuest: false를 반환해야 한다", () => {
+      const payload: UserJwtPayload = { id: "user-123", email: "test@example.com", jti: "jti-1" };
+
+      const result = strategy.validate(payload);
+
+      expect(result).toEqual({
+        userId: "user-123",
+        email: "test@example.com",
+        isGuest: false,
+      });
+    });
+
+    it("게스트 토큰이면 ip, isGuest: true를 반환해야 한다", () => {
+      const payload: GuestJwtPayload = { ip: "127.0.0.1", isGuest: true, jti: "jti-2" };
+
+      const result = strategy.validate(payload);
+
+      expect(result).toEqual({
+        ip: "127.0.0.1",
+        isGuest: true,
+      });
+    });
+
+    it("사용자 토큰에 id가 없으면 UnauthorizedException을 던져야 한다", () => {
+      const payload: UserJwtPayload = { id: "", email: "test@example.com", jti: "jti-3" };
+
+      expect(() => strategy.validate(payload)).toThrow(UnauthorizedException);
+    });
+
+    it("사용자 토큰에 email이 없으면 UnauthorizedException을 던져야 한다", () => {
+      const payload: UserJwtPayload = { id: "user-123", email: "", jti: "jti-4" };
+
+      expect(() => strategy.validate(payload)).toThrow(UnauthorizedException);
+    });
+
+    it("필드 누락 시 TOKEN_INVALID 에러 코드를 포함해야 한다", () => {
+      const payload: UserJwtPayload = { id: "", email: "", jti: "jti-5" };
+
+      expect(() => strategy.validate(payload)).toThrow(
+        new UnauthorizedException(ERROR_CODES.TOKEN_INVALID),
+      );
+    });
+  });
+});

--- a/src/auth/utils/ip-hash.util.spec.ts
+++ b/src/auth/utils/ip-hash.util.spec.ts
@@ -1,0 +1,51 @@
+import { hashIp } from "./ip-hash.util";
+
+describe("hashIp", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, IP_SECRET_KEY: "test-secret-key" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("동일 IP에 대해 동일 해시를 반환해야 한다", () => {
+    const hash1 = hashIp("192.168.1.1");
+    const hash2 = hashIp("192.168.1.1");
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it("다른 IP에 대해 다른 해시를 반환해야 한다", () => {
+    const hash1 = hashIp("192.168.1.1");
+    const hash2 = hashIp("10.0.0.1");
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("HMAC-SHA256 hex 형식(64자)을 반환해야 한다", () => {
+    const hash = hashIp("192.168.1.1");
+
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("IP_SECRET_KEY가 미설정이면 에러를 던져야 한다", () => {
+    delete process.env.IP_SECRET_KEY;
+
+    expect(() => hashIp("192.168.1.1")).toThrow(
+      "IP_SECRET_KEY is not defined in environment variables",
+    );
+  });
+
+  it("다른 시크릿 키로 다른 해시를 생성해야 한다", () => {
+    const hash1 = hashIp("192.168.1.1");
+
+    process.env.IP_SECRET_KEY = "different-secret-key";
+    const hash2 = hashIp("192.168.1.1");
+
+    expect(hash1).not.toBe(hash2);
+  });
+});

--- a/src/common/filters/all-exceptions.filter.spec.ts
+++ b/src/common/filters/all-exceptions.filter.spec.ts
@@ -9,12 +9,20 @@ import { ConfigService } from "@nestjs/config";
 import { Test, type TestingModule } from "@nestjs/testing";
 import { AllExceptionsFilter } from "./all-exceptions.filter";
 
-const createMockHost = (): {
+interface MockHostOptions {
+  onJson?: (body: Record<string, unknown>) => void;
+}
+
+const createMockHost = (
+  options?: MockHostOptions,
+): {
   host: ArgumentsHost;
   mockStatus: jest.Mock;
   mockJson: jest.Mock;
 } => {
-  const mockJson = jest.fn();
+  const mockJson = jest.fn((body: Record<string, unknown>) => {
+    options?.onJson?.(body);
+  });
   const mockStatus = jest.fn().mockReturnValue({ json: mockJson });
   const host: ArgumentsHost = {
     switchToHttp: jest.fn().mockReturnValue({
@@ -34,6 +42,9 @@ const createMockHost = (): {
 describe("AllExceptionsFilter", () => {
   let filter: AllExceptionsFilter;
   let devFilter: AllExceptionsFilter;
+  let host: ArgumentsHost;
+  let mockStatus: jest.Mock;
+  let mockJson: jest.Mock;
 
   const mockConfigService = {
     get: jest.fn().mockReturnValue("production"),
@@ -55,11 +66,16 @@ describe("AllExceptionsFilter", () => {
     }).compile();
 
     devFilter = devModule.get<AllExceptionsFilter>(AllExceptionsFilter);
+
+    ({ host, mockStatus, mockJson } = createMockHost());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   describe("catch", () => {
     it("HttpException 문자열 응답에서 ERROR_MESSAGES를 조회해야 한다", () => {
-      const { host, mockStatus, mockJson } = createMockHost();
       const exception = new HttpException("EMPTY_TEXT", HttpStatus.BAD_REQUEST);
 
       filter.catch(exception, host);
@@ -75,7 +91,6 @@ describe("AllExceptionsFilter", () => {
     });
 
     it("ValidationError를 올바르게 처리해야 한다", () => {
-      const { host, mockStatus, mockJson } = createMockHost();
       const exception = new BadRequestException({
         message: ["이메일 형식이 올바르지 않습니다."],
         error: "Bad Request",
@@ -93,7 +108,6 @@ describe("AllExceptionsFilter", () => {
     });
 
     it("ValidationError 배열의 첫 메시지를 사용해야 한다", () => {
-      const { host, mockJson } = createMockHost();
       const exception = new BadRequestException({
         message: ["첫 번째 에러", "두 번째 에러"],
         error: "Bad Request",
@@ -109,7 +123,6 @@ describe("AllExceptionsFilter", () => {
     });
 
     it("HttpException 객체 응답에서 ERROR_MESSAGES에 있는 message를 매핑해야 한다", () => {
-      const { host, mockJson } = createMockHost();
       const exception = new NotFoundException("FACTCHECK_NOT_FOUND");
 
       filter.catch(exception, host);
@@ -123,7 +136,6 @@ describe("AllExceptionsFilter", () => {
     });
 
     it("5xx 에러를 '서버 오류가 발생했습니다.'로 마스킹해야 한다", () => {
-      const { host, mockJson } = createMockHost();
       const exception = new Error("DB connection failed");
 
       filter.catch(exception, host);
@@ -137,7 +149,6 @@ describe("AllExceptionsFilter", () => {
     });
 
     it("5xx 에러의 statusCode를 500으로 통일해야 한다", () => {
-      const { host, mockStatus } = createMockHost();
       const exception = new HttpException("서버 에러", HttpStatus.BAD_GATEWAY);
 
       filter.catch(exception, host);
@@ -147,21 +158,11 @@ describe("AllExceptionsFilter", () => {
 
     it("dev 환경 4xx에서 stack trace를 포함해야 한다", () => {
       let capturedResponse: Record<string, unknown> = {};
-      const capturingJson = jest.fn((body: Record<string, unknown>) => {
-        capturedResponse = body;
+      const { host: capturingHost } = createMockHost({
+        onJson: (body) => {
+          capturedResponse = body;
+        },
       });
-      const capturingStatus = jest.fn().mockReturnValue({ json: capturingJson });
-      const capturingHost: ArgumentsHost = {
-        switchToHttp: jest.fn().mockReturnValue({
-          getResponse: jest.fn().mockReturnValue({ status: capturingStatus }),
-          getRequest: jest.fn().mockReturnValue({ method: "GET", url: "/test" }),
-        }),
-        switchToRpc: jest.fn(),
-        switchToWs: jest.fn(),
-        getArgs: jest.fn(),
-        getArgByIndex: jest.fn(),
-        getType: jest.fn(),
-      };
       const exception = new BadRequestException("EMPTY_TEXT");
 
       devFilter.catch(exception, capturingHost);
@@ -171,21 +172,11 @@ describe("AllExceptionsFilter", () => {
 
     it("production 환경에서 stack trace를 포함하지 않아야 한다", () => {
       let capturedResponse: Record<string, unknown> = {};
-      const capturingJson = jest.fn((body: Record<string, unknown>) => {
-        capturedResponse = body;
+      const { host: capturingHost } = createMockHost({
+        onJson: (body) => {
+          capturedResponse = body;
+        },
       });
-      const capturingStatus = jest.fn().mockReturnValue({ json: capturingJson });
-      const capturingHost: ArgumentsHost = {
-        switchToHttp: jest.fn().mockReturnValue({
-          getResponse: jest.fn().mockReturnValue({ status: capturingStatus }),
-          getRequest: jest.fn().mockReturnValue({ method: "GET", url: "/test" }),
-        }),
-        switchToRpc: jest.fn(),
-        switchToWs: jest.fn(),
-        getArgs: jest.fn(),
-        getArgByIndex: jest.fn(),
-        getType: jest.fn(),
-      };
       const exception = new BadRequestException("EMPTY_TEXT");
 
       filter.catch(exception, capturingHost);
@@ -194,7 +185,6 @@ describe("AllExceptionsFilter", () => {
     });
 
     it("ERROR_MESSAGES에 없는 문자열 응답은 원본을 그대로 사용해야 한다", () => {
-      const { host, mockJson } = createMockHost();
       const exception = new HttpException("unknown", 418);
 
       filter.catch(exception, host);
@@ -209,7 +199,6 @@ describe("AllExceptionsFilter", () => {
     });
 
     it("일반 Error(비-HttpException)를 500으로 처리해야 한다", () => {
-      const { host, mockStatus, mockJson } = createMockHost();
       const exception = new TypeError("Cannot read properties of undefined");
 
       filter.catch(exception, host);

--- a/src/common/filters/all-exceptions.filter.spec.ts
+++ b/src/common/filters/all-exceptions.filter.spec.ts
@@ -9,20 +9,17 @@ import { ConfigService } from "@nestjs/config";
 import { Test, type TestingModule } from "@nestjs/testing";
 import { AllExceptionsFilter } from "./all-exceptions.filter";
 
-interface MockHostOptions {
-  onJson?: (body: Record<string, unknown>) => void;
-}
+type JsonBody = Record<string, unknown>;
 
-const createMockHost = (
-  options?: MockHostOptions,
-): {
+type MockJsonFn = (_body: JsonBody) => void;
+
+const createMockHost = (): {
   host: ArgumentsHost;
   mockStatus: jest.Mock;
-  mockJson: jest.Mock;
+  mockJson: jest.MockWithArgs<MockJsonFn>;
 } => {
-  const mockJson = jest.fn((body: Record<string, unknown>) => {
-    options?.onJson?.(body);
-  });
+  const jsonNoop: MockJsonFn = () => {};
+  const mockJson = jest.fn(jsonNoop);
   const mockStatus = jest.fn().mockReturnValue({ json: mockJson });
   const host: ArgumentsHost = {
     switchToHttp: jest.fn().mockReturnValue({
@@ -44,7 +41,7 @@ describe("AllExceptionsFilter", () => {
   let devFilter: AllExceptionsFilter;
   let host: ArgumentsHost;
   let mockStatus: jest.Mock;
-  let mockJson: jest.Mock;
+  let mockJson: jest.MockWithArgs<MockJsonFn>;
 
   const mockConfigService = {
     get: jest.fn().mockReturnValue("production"),
@@ -157,31 +154,21 @@ describe("AllExceptionsFilter", () => {
     });
 
     it("dev 환경 4xx에서 stack trace를 포함해야 한다", () => {
-      let capturedResponse: Record<string, unknown> = {};
-      const { host: capturingHost } = createMockHost({
-        onJson: (body) => {
-          capturedResponse = body;
-        },
-      });
+      const { host: capturingHost, mockJson: capturingJson } = createMockHost();
       const exception = new BadRequestException("EMPTY_TEXT");
 
       devFilter.catch(exception, capturingHost);
 
-      expect(capturedResponse).toHaveProperty("stack");
+      expect(capturingJson.mock.calls[0][0]).toHaveProperty("stack");
     });
 
     it("production 환경에서 stack trace를 포함하지 않아야 한다", () => {
-      let capturedResponse: Record<string, unknown> = {};
-      const { host: capturingHost } = createMockHost({
-        onJson: (body) => {
-          capturedResponse = body;
-        },
-      });
+      const { host: capturingHost, mockJson: capturingJson } = createMockHost();
       const exception = new BadRequestException("EMPTY_TEXT");
 
       filter.catch(exception, capturingHost);
 
-      expect(capturedResponse).not.toHaveProperty("stack");
+      expect(capturingJson.mock.calls[0][0]).not.toHaveProperty("stack");
     });
 
     it("ERROR_MESSAGES에 없는 문자열 응답은 원본을 그대로 사용해야 한다", () => {

--- a/src/common/filters/all-exceptions.filter.spec.ts
+++ b/src/common/filters/all-exceptions.filter.spec.ts
@@ -1,0 +1,227 @@
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  type ArgumentsHost,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { AllExceptionsFilter } from "./all-exceptions.filter";
+
+const createMockHost = (): {
+  host: ArgumentsHost;
+  mockStatus: jest.Mock;
+  mockJson: jest.Mock;
+} => {
+  const mockJson = jest.fn();
+  const mockStatus = jest.fn().mockReturnValue({ json: mockJson });
+  const host: ArgumentsHost = {
+    switchToHttp: jest.fn().mockReturnValue({
+      getResponse: jest.fn().mockReturnValue({ status: mockStatus }),
+      getRequest: jest.fn().mockReturnValue({ method: "GET", url: "/test" }),
+    }),
+    switchToRpc: jest.fn(),
+    switchToWs: jest.fn(),
+    getArgs: jest.fn(),
+    getArgByIndex: jest.fn(),
+    getType: jest.fn(),
+  };
+
+  return { host, mockStatus, mockJson };
+};
+
+describe("AllExceptionsFilter", () => {
+  let filter: AllExceptionsFilter;
+  let devFilter: AllExceptionsFilter;
+
+  const mockConfigService = {
+    get: jest.fn().mockReturnValue("production"),
+  };
+
+  const mockDevConfigService = {
+    get: jest.fn().mockReturnValue("development"),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AllExceptionsFilter, { provide: ConfigService, useValue: mockConfigService }],
+    }).compile();
+
+    filter = module.get<AllExceptionsFilter>(AllExceptionsFilter);
+
+    const devModule: TestingModule = await Test.createTestingModule({
+      providers: [AllExceptionsFilter, { provide: ConfigService, useValue: mockDevConfigService }],
+    }).compile();
+
+    devFilter = devModule.get<AllExceptionsFilter>(AllExceptionsFilter);
+  });
+
+  describe("catch", () => {
+    it("HttpException 문자열 응답에서 ERROR_MESSAGES를 조회해야 한다", () => {
+      const { host, mockStatus, mockJson } = createMockHost();
+      const exception = new HttpException("EMPTY_TEXT", HttpStatus.BAD_REQUEST);
+
+      filter.catch(exception, host);
+
+      expect(mockStatus).toHaveBeenCalledWith(400);
+      expect(mockJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 400,
+          code: "EMPTY_TEXT",
+          message: "텍스트가 비어있습니다.",
+        }),
+      );
+    });
+
+    it("ValidationError를 올바르게 처리해야 한다", () => {
+      const { host, mockStatus, mockJson } = createMockHost();
+      const exception = new BadRequestException({
+        message: ["이메일 형식이 올바르지 않습니다."],
+        error: "Bad Request",
+      });
+
+      filter.catch(exception, host);
+
+      expect(mockStatus).toHaveBeenCalledWith(400);
+      expect(mockJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: "VALIDATION_ERROR",
+          message: "이메일 형식이 올바르지 않습니다.",
+        }),
+      );
+    });
+
+    it("ValidationError 배열의 첫 메시지를 사용해야 한다", () => {
+      const { host, mockJson } = createMockHost();
+      const exception = new BadRequestException({
+        message: ["첫 번째 에러", "두 번째 에러"],
+        error: "Bad Request",
+      });
+
+      filter.catch(exception, host);
+
+      expect(mockJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "첫 번째 에러",
+        }),
+      );
+    });
+
+    it("HttpException 객체 응답에서 ERROR_MESSAGES에 있는 message를 매핑해야 한다", () => {
+      const { host, mockJson } = createMockHost();
+      const exception = new NotFoundException("FACTCHECK_NOT_FOUND");
+
+      filter.catch(exception, host);
+
+      expect(mockJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: "FACTCHECK_NOT_FOUND",
+          message: "팩트체크 결과를 찾을 수 없습니다.",
+        }),
+      );
+    });
+
+    it("5xx 에러를 '서버 오류가 발생했습니다.'로 마스킹해야 한다", () => {
+      const { host, mockJson } = createMockHost();
+      const exception = new Error("DB connection failed");
+
+      filter.catch(exception, host);
+
+      expect(mockJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        }),
+      );
+    });
+
+    it("5xx 에러의 statusCode를 500으로 통일해야 한다", () => {
+      const { host, mockStatus } = createMockHost();
+      const exception = new HttpException("서버 에러", HttpStatus.BAD_GATEWAY);
+
+      filter.catch(exception, host);
+
+      expect(mockStatus).toHaveBeenCalledWith(500);
+    });
+
+    it("dev 환경 4xx에서 stack trace를 포함해야 한다", () => {
+      let capturedResponse: Record<string, unknown> = {};
+      const capturingJson = jest.fn((body: Record<string, unknown>) => {
+        capturedResponse = body;
+      });
+      const capturingStatus = jest.fn().mockReturnValue({ json: capturingJson });
+      const capturingHost: ArgumentsHost = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getResponse: jest.fn().mockReturnValue({ status: capturingStatus }),
+          getRequest: jest.fn().mockReturnValue({ method: "GET", url: "/test" }),
+        }),
+        switchToRpc: jest.fn(),
+        switchToWs: jest.fn(),
+        getArgs: jest.fn(),
+        getArgByIndex: jest.fn(),
+        getType: jest.fn(),
+      };
+      const exception = new BadRequestException("EMPTY_TEXT");
+
+      devFilter.catch(exception, capturingHost);
+
+      expect(capturedResponse).toHaveProperty("stack");
+    });
+
+    it("production 환경에서 stack trace를 포함하지 않아야 한다", () => {
+      let capturedResponse: Record<string, unknown> = {};
+      const capturingJson = jest.fn((body: Record<string, unknown>) => {
+        capturedResponse = body;
+      });
+      const capturingStatus = jest.fn().mockReturnValue({ json: capturingJson });
+      const capturingHost: ArgumentsHost = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getResponse: jest.fn().mockReturnValue({ status: capturingStatus }),
+          getRequest: jest.fn().mockReturnValue({ method: "GET", url: "/test" }),
+        }),
+        switchToRpc: jest.fn(),
+        switchToWs: jest.fn(),
+        getArgs: jest.fn(),
+        getArgByIndex: jest.fn(),
+        getType: jest.fn(),
+      };
+      const exception = new BadRequestException("EMPTY_TEXT");
+
+      filter.catch(exception, capturingHost);
+
+      expect(capturedResponse).not.toHaveProperty("stack");
+    });
+
+    it("ERROR_MESSAGES에 없는 문자열 응답은 원본을 그대로 사용해야 한다", () => {
+      const { host, mockJson } = createMockHost();
+      const exception = new HttpException("unknown", 418);
+
+      filter.catch(exception, host);
+
+      expect(mockJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 418,
+          code: "unknown",
+          message: "unknown",
+        }),
+      );
+    });
+
+    it("일반 Error(비-HttpException)를 500으로 처리해야 한다", () => {
+      const { host, mockStatus, mockJson } = createMockHost();
+      const exception = new TypeError("Cannot read properties of undefined");
+
+      filter.catch(exception, host);
+
+      expect(mockStatus).toHaveBeenCalledWith(500);
+      expect(mockJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 500,
+          code: "INTERNAL_SERVER_ERROR",
+          message: "서버 오류가 발생했습니다.",
+        }),
+      );
+    });
+  });
+});

--- a/src/factcheck/factcheck.controller.spec.ts
+++ b/src/factcheck/factcheck.controller.spec.ts
@@ -6,7 +6,10 @@ import type { FactCheckRequest } from "./types/factcheck.types";
 
 describe("FactCheckController", () => {
   let controller: FactCheckController;
-  let mockProcessFactCheck: jest.Mock;
+
+  const mockFactCheckService = {
+    processFactCheck: jest.fn(),
+  };
 
   const mockFactCheckResponse: FactCheckResponse = {
     id: "factcheck-123",
@@ -34,16 +37,12 @@ describe("FactCheckController", () => {
   };
 
   beforeEach(async () => {
-    mockProcessFactCheck = jest.fn();
-
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FactCheckController],
       providers: [
         {
           provide: FactCheckService,
-          useValue: {
-            processFactCheck: mockProcessFactCheck,
-          },
+          useValue: mockFactCheckService,
         },
       ],
     }).compile();
@@ -61,11 +60,11 @@ describe("FactCheckController", () => {
       const mockRequest: FactCheckRequest = { user: mockUser };
       const dto = { text: "테스트 텍스트" };
 
-      mockProcessFactCheck.mockResolvedValue(mockFactCheckResponse);
+      mockFactCheckService.processFactCheck.mockResolvedValue(mockFactCheckResponse);
 
       const result = await controller.create(mockRequest, dto);
 
-      expect(mockProcessFactCheck).toHaveBeenCalledWith(mockUser, dto.text);
+      expect(mockFactCheckService.processFactCheck).toHaveBeenCalledWith(mockUser, dto.text);
       expect(result).toEqual(mockFactCheckResponse);
     });
 
@@ -77,11 +76,11 @@ describe("FactCheckController", () => {
       const mockRequest: FactCheckRequest = { user: mockGuestUser };
       const dto = { text: "게스트 테스트" };
 
-      mockProcessFactCheck.mockResolvedValue(mockFactCheckResponse);
+      mockFactCheckService.processFactCheck.mockResolvedValue(mockFactCheckResponse);
 
       await controller.create(mockRequest, dto);
 
-      expect(mockProcessFactCheck).toHaveBeenCalledWith(mockGuestUser, dto.text);
+      expect(mockFactCheckService.processFactCheck).toHaveBeenCalledWith(mockGuestUser, dto.text);
     });
   });
 });

--- a/src/factcheck/factcheck.integration.spec.ts
+++ b/src/factcheck/factcheck.integration.spec.ts
@@ -1,0 +1,480 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from "@nestjs/common";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { GuestRepository } from "../auth/repositories/guest.repository";
+import type { AuthenticatedUser, GuestUser } from "../auth/types/auth.types";
+import { ERROR_CODES } from "../common/constants/error-codes";
+import { McpService } from "../mcp/mcp.service";
+import type { McpResponse } from "../mcp/types/mcp.types";
+import { SettingsService } from "../settings/settings.service";
+import { FactCheckController } from "./factcheck.controller";
+import { FactCheckService } from "./factcheck.service";
+import { FactCheckRepository } from "./repositories/factcheck.repository";
+import { createDbClaim, createDbFactCheck, createDbOpinion } from "./testing/factories";
+import type { FactCheckRequest } from "./types/factcheck.types";
+
+describe("FactCheck Integration", () => {
+  let controller: FactCheckController;
+
+  const mockFactCheckRepository = {
+    saveFactCheck: jest.fn(),
+    findByUserId: jest.fn(),
+    findById: jest.fn(),
+    deleteById: jest.fn(),
+    updateClaimStatus: jest.fn(),
+  };
+
+  const mockMcpService = {
+    analyze: jest.fn(),
+  };
+
+  const mockGuestRepository = {
+    getGuestInfo: jest.fn(),
+    decrementRemainingUses: jest.fn(),
+  };
+
+  const mockSettingsService = {
+    getSettings: jest.fn().mockResolvedValue({ whitelist: [], blacklist: [] }),
+  };
+
+  const authenticatedUser: AuthenticatedUser = {
+    userId: "user-123",
+    email: "test@example.com",
+    isGuest: false as const,
+  };
+
+  const guestUser: GuestUser = {
+    ip: "192.168.1.1",
+    isGuest: true as const,
+  };
+
+  const mockMcpResponse: McpResponse = {
+    title: "팩트체크 결과 제목",
+    originalText: "원본 텍스트",
+    sentences: [
+      {
+        type: "opinion",
+        text: "이것은 의견입니다.",
+        startIndex: 0,
+        endIndex: 9,
+        reason: "주관적 표현",
+        suggestion: null,
+      },
+      {
+        type: "claim",
+        text: "검증 가능한 문장입니다.",
+        startIndex: 10,
+        endIndex: 30,
+        verdict: "TRUE",
+        suggestion: null,
+        sources: [{ title: "출처", url: "https://example.com" }],
+      },
+      {
+        type: "excluded",
+        text: "제외될 문장",
+        startIndex: 31,
+        endIndex: 40,
+        suggestion: null,
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FactCheckController],
+      providers: [
+        FactCheckService,
+        { provide: FactCheckRepository, useValue: mockFactCheckRepository },
+        { provide: McpService, useValue: mockMcpService },
+        { provide: GuestRepository, useValue: mockGuestRepository },
+        { provide: SettingsService, useValue: mockSettingsService },
+      ],
+    }).compile();
+
+    controller = module.get<FactCheckController>(FactCheckController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("create", () => {
+    describe("인증 사용자", () => {
+      it("팩트체크를 수행하고 변환된 응답을 반환해야 한다", async () => {
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
+        mockFactCheckRepository.saveFactCheck.mockResolvedValue(undefined);
+        const req: FactCheckRequest = { user: authenticatedUser };
+
+        const result = await controller.create(req, { text: "테스트 텍스트" });
+
+        expect(result).toHaveProperty("id");
+        expect(result.title).toBe(mockMcpResponse.title);
+        expect(result.originalText).toBe("테스트 텍스트");
+        expect(result.sentences).toHaveLength(2);
+        expect(result).toHaveProperty("summary");
+        expect(result).toHaveProperty("createdAt");
+      });
+
+      it("excluded 문장을 필터링하고 startIndex 기준으로 정렬해야 한다", async () => {
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
+        mockFactCheckRepository.saveFactCheck.mockResolvedValue(undefined);
+        const req: FactCheckRequest = { user: authenticatedUser };
+
+        const result = await controller.create(req, { text: "테스트 텍스트" });
+
+        expect(result.sentences[0].type).toBe("opinion");
+        expect(result.sentences[0].position).toBe(0);
+        expect(result.sentences[1].type).toBe("claim");
+        expect(result.sentences[1].position).toBe(1);
+      });
+
+      it("summary를 정확하게 계산해야 한다", async () => {
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
+        mockFactCheckRepository.saveFactCheck.mockResolvedValue(undefined);
+        const req: FactCheckRequest = { user: authenticatedUser };
+
+        const result = await controller.create(req, { text: "테스트 텍스트" });
+
+        expect(result.summary).toEqual({
+          total: 2,
+          true: 1,
+          false: 0,
+          opinion: 1,
+        });
+      });
+
+      it("FALSE verdict가 포함된 응답의 summary를 정확하게 계산해야 한다", async () => {
+        const mcpResponseWithFalse: McpResponse = {
+          title: "팩트체크 결과",
+          originalText: "원본 텍스트",
+          sentences: [
+            {
+              type: "claim",
+              text: "참인 문장",
+              startIndex: 0,
+              endIndex: 10,
+              verdict: "TRUE",
+              suggestion: null,
+              sources: [{ title: "출처", url: "https://example.com" }],
+            },
+            {
+              type: "claim",
+              text: "거짓인 문장",
+              startIndex: 11,
+              endIndex: 20,
+              verdict: "FALSE",
+              suggestion: "수정된 문장",
+              sources: [{ title: "출처2", url: "https://example2.com" }],
+            },
+            {
+              type: "opinion",
+              text: "의견 문장",
+              startIndex: 21,
+              endIndex: 30,
+              reason: "주관적",
+              suggestion: null,
+            },
+          ],
+        };
+        mockMcpService.analyze.mockResolvedValue(mcpResponseWithFalse);
+        mockFactCheckRepository.saveFactCheck.mockResolvedValue(undefined);
+        const req: FactCheckRequest = { user: authenticatedUser };
+
+        const result = await controller.create(req, { text: "테스트 텍스트" });
+
+        expect(result.summary).toEqual({
+          total: 3,
+          true: 1,
+          false: 1,
+          opinion: 1,
+        });
+        expect(result.sentences).toHaveLength(3);
+      });
+
+      it("DB에 저장하고 사용자 설정을 조회해야 한다", async () => {
+        const filters = { whitelist: ["good.com"], blacklist: ["bad.com"] };
+        mockSettingsService.getSettings.mockResolvedValue(filters);
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
+        mockFactCheckRepository.saveFactCheck.mockResolvedValue(undefined);
+        const req: FactCheckRequest = { user: authenticatedUser };
+
+        await controller.create(req, { text: "테스트 텍스트" });
+
+        expect(mockSettingsService.getSettings).toHaveBeenCalledWith(authenticatedUser.userId);
+        expect(mockMcpService.analyze).toHaveBeenCalledWith("테스트 텍스트", filters);
+        expect(mockFactCheckRepository.saveFactCheck).toHaveBeenCalledWith(
+          authenticatedUser.userId,
+          expect.any(String),
+          mockMcpResponse.title,
+          "테스트 텍스트",
+          expect.any(Array),
+        );
+      });
+
+      it("DB 저장 실패 시 에러를 전파해야 한다", async () => {
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
+        mockFactCheckRepository.saveFactCheck.mockRejectedValue(new Error("DB connection lost"));
+        const req: FactCheckRequest = { user: authenticatedUser };
+
+        await expect(controller.create(req, { text: "테스트 텍스트" })).rejects.toThrow(
+          "DB connection lost",
+        );
+      });
+
+      it("게스트 사용량을 차감하지 않아야 한다", async () => {
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
+        mockFactCheckRepository.saveFactCheck.mockResolvedValue(undefined);
+        const req: FactCheckRequest = { user: authenticatedUser };
+
+        await controller.create(req, { text: "테스트 텍스트" });
+
+        expect(mockGuestRepository.decrementRemainingUses).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("게스트 사용자", () => {
+      it("잔여 횟수가 있으면 팩트체크를 수행해야 한다", async () => {
+        mockGuestRepository.getGuestInfo.mockResolvedValue({
+          remainingUses: 3,
+          createdAt: Date.now(),
+        });
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
+        const req: FactCheckRequest = { user: guestUser };
+
+        const result = await controller.create(req, { text: "게스트 테스트 텍스트" });
+
+        expect(result).toHaveProperty("id");
+        expect(result.sentences).toHaveLength(2);
+        expect(mockGuestRepository.decrementRemainingUses).toHaveBeenCalledWith(guestUser.ip);
+        expect(mockFactCheckRepository.saveFactCheck).not.toHaveBeenCalled();
+      });
+
+      it("한도 초과 시 ForbiddenException을 던져야 한다", async () => {
+        mockGuestRepository.getGuestInfo.mockResolvedValue({
+          remainingUses: 0,
+          createdAt: Date.now(),
+        });
+        const req: FactCheckRequest = { user: guestUser };
+
+        await expect(controller.create(req, { text: "테스트" })).rejects.toThrow(
+          new ForbiddenException(ERROR_CODES.GUEST_LIMIT_EXCEEDED),
+        );
+      });
+
+      it("게스트 정보가 없으면 ForbiddenException을 던져야 한다", async () => {
+        mockGuestRepository.getGuestInfo.mockResolvedValue(null);
+        const req: FactCheckRequest = { user: guestUser };
+
+        await expect(controller.create(req, { text: "테스트" })).rejects.toThrow(
+          new ForbiddenException(ERROR_CODES.GUEST_LIMIT_EXCEEDED),
+        );
+      });
+    });
+
+    describe("빈 텍스트", () => {
+      it("빈 문자열 시 BadRequestException을 던져야 한다", async () => {
+        const req: FactCheckRequest = { user: authenticatedUser };
+
+        await expect(controller.create(req, { text: "" })).rejects.toThrow(
+          new BadRequestException(ERROR_CODES.EMPTY_TEXT),
+        );
+      });
+
+      it("공백만 있는 텍스트 시 BadRequestException을 던져야 한다", async () => {
+        const req: FactCheckRequest = { user: authenticatedUser };
+
+        await expect(controller.create(req, { text: "   " })).rejects.toThrow(
+          new BadRequestException(ERROR_CODES.EMPTY_TEXT),
+        );
+      });
+    });
+  });
+
+  describe("findAll", () => {
+    it("페이지네이션된 히스토리를 반환해야 한다", async () => {
+      mockFactCheckRepository.findByUserId.mockResolvedValue({
+        items: [
+          {
+            id: "fc-1",
+            title: "제목",
+            originalText: "짧은 텍스트",
+            checkedCount: 2,
+            createdAt: new Date("2026-01-01"),
+          },
+        ],
+        total: 1,
+      });
+
+      const result = await controller.findAll(authenticatedUser, { page: 1, limit: 10 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual({
+        id: "fc-1",
+        title: "제목",
+        preview: "짧은 텍스트",
+        checkedCount: 2,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      });
+    });
+
+    it("preview를 100자로 절단해야 한다", async () => {
+      const longText = "가".repeat(200);
+      mockFactCheckRepository.findByUserId.mockResolvedValue({
+        items: [
+          {
+            id: "fc-1",
+            title: "제목",
+            originalText: longText,
+            checkedCount: 1,
+            createdAt: new Date("2026-01-01"),
+          },
+        ],
+        total: 1,
+      });
+
+      const result = await controller.findAll(authenticatedUser, { page: 1, limit: 10 });
+
+      expect(result.items[0].preview).toHaveLength(100);
+    });
+
+    it("히스토리가 없으면 빈 배열을 반환해야 한다", async () => {
+      mockFactCheckRepository.findByUserId.mockResolvedValue({
+        items: [],
+        total: 0,
+      });
+
+      const result = await controller.findAll(authenticatedUser, { page: 1, limit: 10 });
+
+      expect(result.items).toEqual([]);
+      expect(result.pagination.totalPages).toBe(0);
+    });
+  });
+
+  describe("findById", () => {
+    it("팩트체크 결과를 변환하여 반환해야 한다", async () => {
+      const claim = createDbClaim({ id: "1", position: 0 });
+      const opinion = createDbOpinion({ id: "2", position: 1 });
+      mockFactCheckRepository.findById.mockResolvedValue(
+        createDbFactCheck({ sentences: [claim, opinion] }),
+      );
+
+      const result = await controller.findById(authenticatedUser, "fc-123");
+
+      expect(result.id).toBe("fc-123");
+      expect(result.sentences).toHaveLength(2);
+      expect(result.sentences[0].type).toBe("claim");
+      expect(result.sentences[1].type).toBe("opinion");
+      expect(result.summary).toEqual({
+        total: 2,
+        true: 1,
+        false: 0,
+        opinion: 1,
+      });
+    });
+
+    it("존재하지 않는 ID면 NotFoundException을 던져야 한다", async () => {
+      mockFactCheckRepository.findById.mockResolvedValue(null);
+
+      await expect(controller.findById(authenticatedUser, "nonexistent-id")).rejects.toThrow(
+        new NotFoundException(ERROR_CODES.FACTCHECK_NOT_FOUND),
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("팩트체크를 삭제하고 success를 반환해야 한다", async () => {
+      mockFactCheckRepository.deleteById.mockResolvedValue(true);
+
+      const result = await controller.delete(authenticatedUser, "fc-123");
+
+      expect(result).toEqual({ success: true });
+      expect(mockFactCheckRepository.deleteById).toHaveBeenCalledWith(
+        authenticatedUser.userId,
+        "fc-123",
+      );
+    });
+
+    it("존재하지 않는 팩트체크면 NotFoundException을 던져야 한다", async () => {
+      mockFactCheckRepository.deleteById.mockResolvedValue(false);
+
+      await expect(controller.delete(authenticatedUser, "nonexistent-id")).rejects.toThrow(
+        new NotFoundException(ERROR_CODES.FACTCHECK_NOT_FOUND),
+      );
+    });
+  });
+
+  describe("apply", () => {
+    it("인증 사용자면 claim 상태를 applied로 변경해야 한다", async () => {
+      mockFactCheckRepository.updateClaimStatus.mockResolvedValue(true);
+      const req: FactCheckRequest = { user: authenticatedUser };
+
+      const result = await controller.apply(req, "fc-123", "claim-1");
+
+      expect(result).toEqual({ id: "claim-1", status: "applied" });
+      expect(mockFactCheckRepository.updateClaimStatus).toHaveBeenCalledWith(
+        authenticatedUser.userId,
+        "fc-123",
+        "claim-1",
+        "APPLIED",
+      );
+    });
+
+    it("게스트 사용자면 DB 호출 없이 applied 상태를 반환해야 한다", async () => {
+      const req: FactCheckRequest = { user: guestUser };
+
+      const result = await controller.apply(req, "fc-123", "claim-1");
+
+      expect(result).toEqual({ id: "claim-1", status: "applied" });
+      expect(mockFactCheckRepository.updateClaimStatus).not.toHaveBeenCalled();
+    });
+
+    it("존재하지 않는 claim이면 NotFoundException을 던져야 한다", async () => {
+      mockFactCheckRepository.updateClaimStatus.mockResolvedValue(false);
+      const req: FactCheckRequest = { user: authenticatedUser };
+
+      await expect(controller.apply(req, "fc-123", "claim-1")).rejects.toThrow(
+        new NotFoundException(ERROR_CODES.CLAIM_NOT_FOUND),
+      );
+    });
+  });
+
+  describe("ignore", () => {
+    it("인증 사용자면 claim 상태를 ignored로 변경해야 한다", async () => {
+      mockFactCheckRepository.updateClaimStatus.mockResolvedValue(true);
+      const req: FactCheckRequest = { user: authenticatedUser };
+
+      const result = await controller.ignore(req, "fc-123", "claim-1");
+
+      expect(result).toEqual({ id: "claim-1", status: "ignored" });
+      expect(mockFactCheckRepository.updateClaimStatus).toHaveBeenCalledWith(
+        authenticatedUser.userId,
+        "fc-123",
+        "claim-1",
+        "IGNORED",
+      );
+    });
+
+    it("게스트 사용자면 DB 호출 없이 ignored 상태를 반환해야 한다", async () => {
+      const req: FactCheckRequest = { user: guestUser };
+
+      const result = await controller.ignore(req, "fc-123", "claim-1");
+
+      expect(result).toEqual({ id: "claim-1", status: "ignored" });
+      expect(mockFactCheckRepository.updateClaimStatus).not.toHaveBeenCalled();
+    });
+
+    it("존재하지 않는 claim이면 NotFoundException을 던져야 한다", async () => {
+      mockFactCheckRepository.updateClaimStatus.mockResolvedValue(false);
+      const req: FactCheckRequest = { user: authenticatedUser };
+
+      await expect(controller.ignore(req, "fc-123", "claim-1")).rejects.toThrow(
+        new NotFoundException(ERROR_CODES.CLAIM_NOT_FOUND),
+      );
+    });
+  });
+});

--- a/src/factcheck/factcheck.service.spec.ts
+++ b/src/factcheck/factcheck.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ForbiddenException } from "@nestjs/common";
+import { BadRequestException, ForbiddenException, NotFoundException } from "@nestjs/common";
 import { Test, type TestingModule } from "@nestjs/testing";
 import { GuestRepository } from "../auth/repositories/guest.repository";
 import { McpService } from "../mcp/mcp.service";
@@ -9,12 +9,27 @@ import { FactCheckRepository } from "./repositories/factcheck.repository";
 
 describe("FactCheckService", () => {
   let service: FactCheckService;
-  let mockAnalyze: jest.Mock;
-  let mockSaveFactCheck: jest.Mock;
-  let mockGetGuestInfo: jest.Mock;
-  let mockSetGuestInfo: jest.Mock;
-  let mockDecrementRemainingUses: jest.Mock;
-  let mockGetSettings: jest.Mock;
+
+  const mockMcpService = {
+    analyze: jest.fn(),
+  };
+
+  const mockFactCheckRepository = {
+    saveFactCheck: jest.fn(),
+    findByUserId: jest.fn(),
+    findById: jest.fn(),
+    deleteById: jest.fn(),
+  };
+
+  const mockGuestRepository = {
+    getGuestInfo: jest.fn(),
+    setGuestInfo: jest.fn(),
+    decrementRemainingUses: jest.fn(),
+  };
+
+  const mockSettingsService = {
+    getSettings: jest.fn().mockResolvedValue({ whitelist: [], blacklist: [] }),
+  };
 
   const mockMcpResponse: McpResponse = {
     title: "테스트 제목",
@@ -59,42 +74,24 @@ describe("FactCheckService", () => {
   };
 
   beforeEach(async () => {
-    mockAnalyze = jest.fn();
-    mockSaveFactCheck = jest.fn();
-    mockGetGuestInfo = jest.fn();
-    mockSetGuestInfo = jest.fn();
-    mockDecrementRemainingUses = jest.fn();
-
-    mockGetSettings = jest.fn().mockResolvedValue({ whitelist: [], blacklist: [] });
-
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FactCheckService,
         {
           provide: McpService,
-          useValue: {
-            analyze: mockAnalyze,
-          },
+          useValue: mockMcpService,
         },
         {
           provide: FactCheckRepository,
-          useValue: {
-            saveFactCheck: mockSaveFactCheck,
-          },
+          useValue: mockFactCheckRepository,
         },
         {
           provide: GuestRepository,
-          useValue: {
-            getGuestInfo: mockGetGuestInfo,
-            setGuestInfo: mockSetGuestInfo,
-            decrementRemainingUses: mockDecrementRemainingUses,
-          },
+          useValue: mockGuestRepository,
         },
         {
           provide: SettingsService,
-          useValue: {
-            getSettings: mockGetSettings,
-          },
+          useValue: mockSettingsService,
         },
       ],
     }).compile();
@@ -117,7 +114,7 @@ describe("FactCheckService", () => {
 
     describe("Guest User", () => {
       it("게스트 한도 초과 시 ForbiddenException을 던져야 한다", async () => {
-        mockGetGuestInfo.mockResolvedValue({
+        mockGuestRepository.getGuestInfo.mockResolvedValue({
           remainingUses: 0,
           createdAt: Date.now(),
         });
@@ -132,7 +129,7 @@ describe("FactCheckService", () => {
       });
 
       it("게스트 정보가 없으면 ForbiddenException을 던져야 한다", async () => {
-        mockGetGuestInfo.mockResolvedValue(null);
+        mockGuestRepository.getGuestInfo.mockResolvedValue(null);
 
         await expect(service.processFactCheck(mockGuestUser, "테스트 텍스트")).rejects.toThrow(
           ForbiddenException,
@@ -140,30 +137,30 @@ describe("FactCheckService", () => {
       });
 
       it("게스트 정상 요청 시 사용량을 차감해야 한다", async () => {
-        mockGetGuestInfo.mockResolvedValue({
+        mockGuestRepository.getGuestInfo.mockResolvedValue({
           remainingUses: 3,
           createdAt: Date.now(),
         });
-        mockAnalyze.mockResolvedValue(mockMcpResponse);
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
 
         await service.processFactCheck(mockGuestUser, "테스트 텍스트");
 
-        expect(mockDecrementRemainingUses).toHaveBeenCalledWith(mockGuestUser.ip);
+        expect(mockGuestRepository.decrementRemainingUses).toHaveBeenCalledWith(mockGuestUser.ip);
       });
     });
 
     describe("Authenticated User", () => {
       it("로그인 사용자 요청 시 DB에 저장해야 한다", async () => {
         const mockFilters = { whitelist: ["good.com"], blacklist: ["bad.com"] };
-        mockGetSettings.mockResolvedValue(mockFilters);
-        mockAnalyze.mockResolvedValue(mockMcpResponse);
+        mockSettingsService.getSettings.mockResolvedValue(mockFilters);
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
 
         await service.processFactCheck(mockAuthenticatedUser, "테스트 텍스트");
 
-        expect(mockGetSettings).toHaveBeenCalledWith(mockAuthenticatedUser.userId);
-        expect(mockAnalyze).toHaveBeenCalledWith("테스트 텍스트", mockFilters);
+        expect(mockSettingsService.getSettings).toHaveBeenCalledWith(mockAuthenticatedUser.userId);
+        expect(mockMcpService.analyze).toHaveBeenCalledWith("테스트 텍스트", mockFilters);
 
-        expect(mockSaveFactCheck).toHaveBeenCalledWith(
+        expect(mockFactCheckRepository.saveFactCheck).toHaveBeenCalledWith(
           mockAuthenticatedUser.userId,
           expect.any(String),
           mockMcpResponse.title,
@@ -173,17 +170,17 @@ describe("FactCheckService", () => {
       });
 
       it("로그인 사용자는 게스트 사용량을 차감하지 않아야 한다", async () => {
-        mockAnalyze.mockResolvedValue(mockMcpResponse);
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
 
         await service.processFactCheck(mockAuthenticatedUser, "테스트 텍스트");
 
-        expect(mockSetGuestInfo).not.toHaveBeenCalled();
+        expect(mockGuestRepository.setGuestInfo).not.toHaveBeenCalled();
       });
     });
 
     describe("Response Structure", () => {
       it("응답에 필요한 필드들이 포함되어야 한다", async () => {
-        mockAnalyze.mockResolvedValue(mockMcpResponse);
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
 
         const result = await service.processFactCheck(mockAuthenticatedUser, "테스트 텍스트");
 
@@ -196,7 +193,7 @@ describe("FactCheckService", () => {
       });
 
       it("excluded 타입 문장이 필터링되어야 한다", async () => {
-        mockAnalyze.mockResolvedValue(mockMcpResponse);
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
 
         const result = await service.processFactCheck(mockAuthenticatedUser, "테스트 텍스트");
 
@@ -212,7 +209,7 @@ describe("FactCheckService", () => {
       });
 
       it("startIndex 기준으로 정렬 후 position이 할당되어야 한다", async () => {
-        mockAnalyze.mockResolvedValue(mockMcpResponse);
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
 
         const result = await service.processFactCheck(mockAuthenticatedUser, "테스트 텍스트");
 
@@ -224,7 +221,7 @@ describe("FactCheckService", () => {
       });
 
       it("claim 타입에 status: pending이 추가되어야 한다", async () => {
-        mockAnalyze.mockResolvedValue(mockMcpResponse);
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
 
         const result = await service.processFactCheck(mockAuthenticatedUser, "테스트 텍스트");
 
@@ -233,7 +230,7 @@ describe("FactCheckService", () => {
       });
 
       it("startIndex, endIndex가 응답에 포함되지 않아야 한다", async () => {
-        mockAnalyze.mockResolvedValue(mockMcpResponse);
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
 
         const result = await service.processFactCheck(mockAuthenticatedUser, "테스트 텍스트");
 
@@ -246,7 +243,7 @@ describe("FactCheckService", () => {
 
     describe("Summary Calculation", () => {
       it("summary가 정확하게 계산되어야 한다", async () => {
-        mockAnalyze.mockResolvedValue(mockMcpResponse);
+        mockMcpService.analyze.mockResolvedValue(mockMcpResponse);
 
         const result = await service.processFactCheck(mockAuthenticatedUser, "테스트 텍스트");
 
@@ -255,6 +252,275 @@ describe("FactCheckService", () => {
         expect(result.summary.false).toBe(0);
         expect(result.summary.opinion).toBe(1);
       });
+    });
+  });
+
+  describe("getFactCheckHistory", () => {
+    const query = { page: 1, limit: 10 };
+
+    it("페이지네이션된 히스토리를 반환해야 한다", async () => {
+      mockFactCheckRepository.findByUserId.mockResolvedValue({
+        items: [
+          {
+            id: "fc-1",
+            title: "제목 1",
+            originalText: "짧은 텍스트",
+            checkedCount: 3,
+            createdAt: new Date("2026-01-01"),
+          },
+        ],
+        total: 1,
+      });
+
+      const result = await service.getFactCheckHistory(mockAuthenticatedUser, query);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual({
+        id: "fc-1",
+        title: "제목 1",
+        preview: "짧은 텍스트",
+        checkedCount: 3,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      });
+    });
+
+    it("preview를 100자로 절단해야 한다", async () => {
+      const longText = "가".repeat(200);
+      mockFactCheckRepository.findByUserId.mockResolvedValue({
+        items: [
+          {
+            id: "fc-1",
+            title: "제목",
+            originalText: longText,
+            checkedCount: 1,
+            createdAt: new Date("2026-01-01"),
+          },
+        ],
+        total: 1,
+      });
+
+      const result = await service.getFactCheckHistory(mockAuthenticatedUser, query);
+
+      expect(result.items[0].preview).toHaveLength(100);
+    });
+
+    it("totalPages를 올바르게 계산해야 한다", async () => {
+      mockFactCheckRepository.findByUserId.mockResolvedValue({
+        items: [],
+        total: 25,
+      });
+
+      const result = await service.getFactCheckHistory(mockAuthenticatedUser, {
+        page: 1,
+        limit: 10,
+      });
+
+      expect(result.pagination.totalPages).toBe(3);
+    });
+
+    it("히스토리가 없으면 빈 배열을 반환해야 한다", async () => {
+      mockFactCheckRepository.findByUserId.mockResolvedValue({
+        items: [],
+        total: 0,
+      });
+
+      const result = await service.getFactCheckHistory(mockAuthenticatedUser, query);
+
+      expect(result.items).toEqual([]);
+      expect(result.pagination.totalPages).toBe(0);
+    });
+  });
+
+  describe("getFactCheckById", () => {
+    const factCheckId = "fc-123";
+
+    it("팩트체크 결과를 반환해야 한다", async () => {
+      mockFactCheckRepository.findById.mockResolvedValue({
+        id: factCheckId,
+        title: "테스트 제목",
+        originalText: "원본 텍스트",
+        createdAt: new Date("2026-01-01"),
+        sentences: [
+          {
+            id: 1,
+            type: "CLAIM",
+            text: "검증 문장",
+            position: 0,
+            verdict: "TRUE",
+            suggestion: null,
+            sources: [{ title: "출처", url: "https://example.com" }],
+            status: "PENDING",
+            reason: null,
+          },
+        ],
+      });
+
+      const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
+
+      expect(result).toHaveProperty("id", factCheckId);
+      expect(result).toHaveProperty("sentences");
+      expect(result).toHaveProperty("summary");
+      expect(result).toHaveProperty("createdAt", "2026-01-01T00:00:00.000Z");
+    });
+
+    it("claim 문장을 올바르게 변환해야 한다", async () => {
+      mockFactCheckRepository.findById.mockResolvedValue({
+        id: factCheckId,
+        title: "제목",
+        originalText: "텍스트",
+        createdAt: new Date("2026-01-01"),
+        sentences: [
+          {
+            id: 1,
+            type: "CLAIM",
+            text: "검증 문장",
+            position: 0,
+            verdict: "TRUE",
+            suggestion: "수정 제안",
+            sources: [{ title: "출처", url: "https://example.com" }],
+            status: "APPLIED",
+            reason: null,
+          },
+        ],
+      });
+
+      const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
+      const claim = result.sentences[0];
+
+      expect(claim.type).toBe("claim");
+      expect(claim).toHaveProperty("verdict", "TRUE");
+      expect(claim).toHaveProperty("sources");
+      expect(claim).toHaveProperty("suggestion", "수정 제안");
+      expect(claim).toHaveProperty("status", "applied");
+    });
+
+    it("opinion 문장을 올바르게 변환해야 한다", async () => {
+      mockFactCheckRepository.findById.mockResolvedValue({
+        id: factCheckId,
+        title: "제목",
+        originalText: "텍스트",
+        createdAt: new Date("2026-01-01"),
+        sentences: [
+          {
+            id: 2,
+            type: "OPINION",
+            text: "의견 문장",
+            position: 0,
+            verdict: null,
+            suggestion: null,
+            sources: null,
+            status: null,
+            reason: "주관적 표현",
+          },
+        ],
+      });
+
+      const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
+      const opinion = result.sentences[0];
+
+      expect(opinion.type).toBe("opinion");
+      expect(opinion).toHaveProperty("reason", "주관적 표현");
+      expect(opinion).not.toHaveProperty("verdict");
+      expect(opinion).not.toHaveProperty("sources");
+    });
+
+    it("summary를 올바르게 계산해야 한다", async () => {
+      mockFactCheckRepository.findById.mockResolvedValue({
+        id: factCheckId,
+        title: "제목",
+        originalText: "텍스트",
+        createdAt: new Date("2026-01-01"),
+        sentences: [
+          {
+            id: 1,
+            type: "CLAIM",
+            text: "참 문장",
+            position: 0,
+            verdict: "TRUE",
+            suggestion: null,
+            sources: [],
+            status: "PENDING",
+            reason: null,
+          },
+          {
+            id: 2,
+            type: "CLAIM",
+            text: "거짓 문장",
+            position: 1,
+            verdict: "FALSE",
+            suggestion: "수정",
+            sources: [],
+            status: "PENDING",
+            reason: null,
+          },
+          {
+            id: 3,
+            type: "OPINION",
+            text: "의견",
+            position: 2,
+            verdict: null,
+            suggestion: null,
+            sources: null,
+            status: null,
+            reason: "주관적",
+          },
+        ],
+      });
+
+      const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
+
+      expect(result.summary).toEqual({
+        total: 3,
+        true: 1,
+        false: 1,
+        opinion: 1,
+      });
+    });
+
+    it("존재하지 않는 ID면 NotFoundException을 던져야 한다", async () => {
+      mockFactCheckRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        service.getFactCheckById(mockAuthenticatedUser, "nonexistent-id"),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("deleteFactCheck", () => {
+    const factCheckId = "fc-123";
+
+    it("팩트체크를 정상적으로 삭제해야 한다", async () => {
+      mockFactCheckRepository.deleteById.mockResolvedValue(true);
+
+      const result = await service.deleteFactCheck(mockAuthenticatedUser, factCheckId);
+
+      expect(result).toEqual({ success: true });
+      expect(mockFactCheckRepository.deleteById).toHaveBeenCalledWith(
+        mockAuthenticatedUser.userId,
+        factCheckId,
+      );
+    });
+
+    it("존재하지 않는 팩트체크면 NotFoundException을 던져야 한다", async () => {
+      mockFactCheckRepository.deleteById.mockResolvedValue(false);
+
+      await expect(
+        service.deleteFactCheck(mockAuthenticatedUser, "nonexistent-id"),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("다른 사용자의 팩트체크면 NotFoundException을 던져야 한다", async () => {
+      mockFactCheckRepository.deleteById.mockResolvedValue(false);
+
+      await expect(service.deleteFactCheck(mockAuthenticatedUser, factCheckId)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/src/factcheck/factcheck.service.spec.ts
+++ b/src/factcheck/factcheck.service.spec.ts
@@ -6,61 +6,7 @@ import type { McpResponse } from "../mcp/types/mcp.types";
 import { SettingsService } from "../settings/settings.service";
 import { FactCheckService } from "./factcheck.service";
 import { FactCheckRepository } from "./repositories/factcheck.repository";
-
-interface MockDbSentence {
-  id: string;
-  type: "CLAIM" | "OPINION";
-  text: string;
-  position: number;
-  verdict: "TRUE" | "FALSE" | null;
-  suggestion: string | null;
-  sources: Array<{ title: string; url: string }> | null;
-  status: "PENDING" | "APPLIED" | "IGNORED" | null;
-  reason: string | null;
-}
-
-interface MockDbFactCheck {
-  id: string;
-  title: string;
-  originalText: string;
-  createdAt: Date;
-  sentences: MockDbSentence[];
-}
-
-const createDbClaim = (overrides?: Partial<MockDbSentence>): MockDbSentence => ({
-  id: "1",
-  type: "CLAIM",
-  text: "검증 문장",
-  position: 0,
-  verdict: "TRUE",
-  suggestion: null,
-  sources: [{ title: "출처", url: "https://example.com" }],
-  status: "PENDING",
-  reason: null,
-  ...overrides,
-});
-
-const createDbOpinion = (overrides?: Partial<MockDbSentence>): MockDbSentence => ({
-  id: "2",
-  type: "OPINION",
-  text: "의견 문장",
-  position: 0,
-  verdict: null,
-  suggestion: null,
-  sources: null,
-  status: null,
-  reason: "주관적 표현",
-  ...overrides,
-});
-
-const createDbFactCheck = (overrides?: Partial<MockDbFactCheck>): MockDbFactCheck => ({
-  id: "fc-123",
-  title: "제목",
-  originalText: "텍스트",
-  createdAt: new Date("2026-01-01"),
-  sentences: [],
-  ...overrides,
-});
+import { createDbClaim, createDbFactCheck, createDbOpinion } from "./testing/factories";
 
 describe("FactCheckService", () => {
   let service: FactCheckService;

--- a/src/factcheck/factcheck.service.spec.ts
+++ b/src/factcheck/factcheck.service.spec.ts
@@ -7,6 +7,61 @@ import { SettingsService } from "../settings/settings.service";
 import { FactCheckService } from "./factcheck.service";
 import { FactCheckRepository } from "./repositories/factcheck.repository";
 
+interface MockDbSentence {
+  id: string;
+  type: "CLAIM" | "OPINION";
+  text: string;
+  position: number;
+  verdict: "TRUE" | "FALSE" | null;
+  suggestion: string | null;
+  sources: Array<{ title: string; url: string }> | null;
+  status: "PENDING" | "APPLIED" | "IGNORED" | null;
+  reason: string | null;
+}
+
+interface MockDbFactCheck {
+  id: string;
+  title: string;
+  originalText: string;
+  createdAt: Date;
+  sentences: MockDbSentence[];
+}
+
+const createDbClaim = (overrides?: Partial<MockDbSentence>): MockDbSentence => ({
+  id: "1",
+  type: "CLAIM",
+  text: "검증 문장",
+  position: 0,
+  verdict: "TRUE",
+  suggestion: null,
+  sources: [{ title: "출처", url: "https://example.com" }],
+  status: "PENDING",
+  reason: null,
+  ...overrides,
+});
+
+const createDbOpinion = (overrides?: Partial<MockDbSentence>): MockDbSentence => ({
+  id: "2",
+  type: "OPINION",
+  text: "의견 문장",
+  position: 0,
+  verdict: null,
+  suggestion: null,
+  sources: null,
+  status: null,
+  reason: "주관적 표현",
+  ...overrides,
+});
+
+const createDbFactCheck = (overrides?: Partial<MockDbFactCheck>): MockDbFactCheck => ({
+  id: "fc-123",
+  title: "제목",
+  originalText: "텍스트",
+  createdAt: new Date("2026-01-01"),
+  sentences: [],
+  ...overrides,
+});
+
 describe("FactCheckService", () => {
   let service: FactCheckService;
 
@@ -19,6 +74,7 @@ describe("FactCheckService", () => {
     findByUserId: jest.fn(),
     findById: jest.fn(),
     deleteById: jest.fn(),
+    updateClaimStatus: jest.fn(),
   };
 
   const mockGuestRepository = {
@@ -341,25 +397,9 @@ describe("FactCheckService", () => {
     const factCheckId = "fc-123";
 
     it("팩트체크 결과를 반환해야 한다", async () => {
-      mockFactCheckRepository.findById.mockResolvedValue({
-        id: factCheckId,
-        title: "테스트 제목",
-        originalText: "원본 텍스트",
-        createdAt: new Date("2026-01-01"),
-        sentences: [
-          {
-            id: 1,
-            type: "CLAIM",
-            text: "검증 문장",
-            position: 0,
-            verdict: "TRUE",
-            suggestion: null,
-            sources: [{ title: "출처", url: "https://example.com" }],
-            status: "PENDING",
-            reason: null,
-          },
-        ],
-      });
+      mockFactCheckRepository.findById.mockResolvedValue(
+        createDbFactCheck({ sentences: [createDbClaim()] }),
+      );
 
       const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
 
@@ -370,25 +410,10 @@ describe("FactCheckService", () => {
     });
 
     it("claim 문장을 올바르게 변환해야 한다", async () => {
-      mockFactCheckRepository.findById.mockResolvedValue({
-        id: factCheckId,
-        title: "제목",
-        originalText: "텍스트",
-        createdAt: new Date("2026-01-01"),
-        sentences: [
-          {
-            id: 1,
-            type: "CLAIM",
-            text: "검증 문장",
-            position: 0,
-            verdict: "TRUE",
-            suggestion: "수정 제안",
-            sources: [{ title: "출처", url: "https://example.com" }],
-            status: "APPLIED",
-            reason: null,
-          },
-        ],
-      });
+      const appliedClaim = createDbClaim({ suggestion: "수정 제안", status: "APPLIED" });
+      mockFactCheckRepository.findById.mockResolvedValue(
+        createDbFactCheck({ sentences: [appliedClaim] }),
+      );
 
       const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
       const claim = result.sentences[0];
@@ -401,25 +426,9 @@ describe("FactCheckService", () => {
     });
 
     it("opinion 문장을 올바르게 변환해야 한다", async () => {
-      mockFactCheckRepository.findById.mockResolvedValue({
-        id: factCheckId,
-        title: "제목",
-        originalText: "텍스트",
-        createdAt: new Date("2026-01-01"),
-        sentences: [
-          {
-            id: 2,
-            type: "OPINION",
-            text: "의견 문장",
-            position: 0,
-            verdict: null,
-            suggestion: null,
-            sources: null,
-            status: null,
-            reason: "주관적 표현",
-          },
-        ],
-      });
+      mockFactCheckRepository.findById.mockResolvedValue(
+        createDbFactCheck({ sentences: [createDbOpinion()] }),
+      );
 
       const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
       const opinion = result.sentences[0];
@@ -431,47 +440,18 @@ describe("FactCheckService", () => {
     });
 
     it("summary를 올바르게 계산해야 한다", async () => {
-      mockFactCheckRepository.findById.mockResolvedValue({
-        id: factCheckId,
-        title: "제목",
-        originalText: "텍스트",
-        createdAt: new Date("2026-01-01"),
-        sentences: [
-          {
-            id: 1,
-            type: "CLAIM",
-            text: "참 문장",
-            position: 0,
-            verdict: "TRUE",
-            suggestion: null,
-            sources: [],
-            status: "PENDING",
-            reason: null,
-          },
-          {
-            id: 2,
-            type: "CLAIM",
-            text: "거짓 문장",
-            position: 1,
-            verdict: "FALSE",
-            suggestion: "수정",
-            sources: [],
-            status: "PENDING",
-            reason: null,
-          },
-          {
-            id: 3,
-            type: "OPINION",
-            text: "의견",
-            position: 2,
-            verdict: null,
-            suggestion: null,
-            sources: null,
-            status: null,
-            reason: "주관적",
-          },
-        ],
+      const trueClaim = createDbClaim({ text: "참 문장" });
+      const falseClaim = createDbClaim({
+        id: "2",
+        text: "거짓 문장",
+        position: 1,
+        verdict: "FALSE",
+        suggestion: "수정",
       });
+      const opinion = createDbOpinion({ id: "3", text: "의견", position: 2, reason: "주관적" });
+      mockFactCheckRepository.findById.mockResolvedValue(
+        createDbFactCheck({ sentences: [trueClaim, falseClaim, opinion] }),
+      );
 
       const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
 
@@ -481,6 +461,50 @@ describe("FactCheckService", () => {
         false: 1,
         opinion: 1,
       });
+    });
+
+    it("verdict가 null인 claim은 'FALSE'로 기본값 설정해야 한다", async () => {
+      const claimWithNullVerdict = createDbClaim({ verdict: null });
+      mockFactCheckRepository.findById.mockResolvedValue(
+        createDbFactCheck({ sentences: [claimWithNullVerdict] }),
+      );
+
+      const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
+
+      expect(result.sentences[0]).toHaveProperty("verdict", "FALSE");
+    });
+
+    it("status가 null인 claim은 'pending'으로 기본값 설정해야 한다", async () => {
+      const claimWithNullStatus = createDbClaim({ status: null });
+      mockFactCheckRepository.findById.mockResolvedValue(
+        createDbFactCheck({ sentences: [claimWithNullStatus] }),
+      );
+
+      const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
+
+      expect(result.sentences[0]).toHaveProperty("status", "pending");
+    });
+
+    it("reason이 null인 opinion은 빈 문자열로 기본값 설정해야 한다", async () => {
+      const opinionWithNullReason = createDbOpinion({ id: "1", reason: null });
+      mockFactCheckRepository.findById.mockResolvedValue(
+        createDbFactCheck({ sentences: [opinionWithNullReason] }),
+      );
+
+      const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
+
+      expect(result.sentences[0]).toHaveProperty("reason", "");
+    });
+
+    it("sources가 null인 claim은 빈 배열로 기본값 설정해야 한다", async () => {
+      const claimWithNullSources = createDbClaim({ sources: null });
+      mockFactCheckRepository.findById.mockResolvedValue(
+        createDbFactCheck({ sentences: [claimWithNullSources] }),
+      );
+
+      const result = await service.getFactCheckById(mockAuthenticatedUser, factCheckId);
+
+      expect(result.sentences[0]).toHaveProperty("sources", []);
     });
 
     it("존재하지 않는 ID면 NotFoundException을 던져야 한다", async () => {
@@ -521,6 +545,74 @@ describe("FactCheckService", () => {
       await expect(service.deleteFactCheck(mockAuthenticatedUser, factCheckId)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe("applyClaim", () => {
+    const factCheckId = "fc-123";
+    const claimId = "claim-1";
+
+    it("게스트 사용자면 DB 호출 없이 applied 상태를 반환해야 한다", async () => {
+      const result = await service.applyClaim(mockGuestUser, factCheckId, claimId);
+
+      expect(result).toEqual({ id: claimId, status: "applied" });
+      expect(mockFactCheckRepository.updateClaimStatus).not.toHaveBeenCalled();
+    });
+
+    it("인증 사용자면 updateClaimStatus를 호출해야 한다", async () => {
+      mockFactCheckRepository.updateClaimStatus.mockResolvedValue(true);
+
+      const result = await service.applyClaim(mockAuthenticatedUser, factCheckId, claimId);
+
+      expect(result).toEqual({ id: claimId, status: "applied" });
+      expect(mockFactCheckRepository.updateClaimStatus).toHaveBeenCalledWith(
+        mockAuthenticatedUser.userId,
+        factCheckId,
+        claimId,
+        "APPLIED",
+      );
+    });
+
+    it("존재하지 않는 claim이면 NotFoundException을 던져야 한다", async () => {
+      mockFactCheckRepository.updateClaimStatus.mockResolvedValue(false);
+
+      await expect(service.applyClaim(mockAuthenticatedUser, factCheckId, claimId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe("ignoreClaim", () => {
+    const factCheckId = "fc-123";
+    const claimId = "claim-1";
+
+    it("게스트 사용자면 DB 호출 없이 ignored 상태를 반환해야 한다", async () => {
+      const result = await service.ignoreClaim(mockGuestUser, factCheckId, claimId);
+
+      expect(result).toEqual({ id: claimId, status: "ignored" });
+      expect(mockFactCheckRepository.updateClaimStatus).not.toHaveBeenCalled();
+    });
+
+    it("인증 사용자면 updateClaimStatus를 호출해야 한다", async () => {
+      mockFactCheckRepository.updateClaimStatus.mockResolvedValue(true);
+
+      const result = await service.ignoreClaim(mockAuthenticatedUser, factCheckId, claimId);
+
+      expect(result).toEqual({ id: claimId, status: "ignored" });
+      expect(mockFactCheckRepository.updateClaimStatus).toHaveBeenCalledWith(
+        mockAuthenticatedUser.userId,
+        factCheckId,
+        claimId,
+        "IGNORED",
+      );
+    });
+
+    it("존재하지 않는 claim이면 NotFoundException을 던져야 한다", async () => {
+      mockFactCheckRepository.updateClaimStatus.mockResolvedValue(false);
+
+      await expect(
+        service.ignoreClaim(mockAuthenticatedUser, factCheckId, claimId),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/factcheck/repositories/factcheck.repository.spec.ts
+++ b/src/factcheck/repositories/factcheck.repository.spec.ts
@@ -1,0 +1,386 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ClaimStatus, SentenceType } from "@prisma/client";
+import { PrismaService } from "../../prisma/prisma.service";
+import { createClaimResponse, createOpinionResponse } from "../testing/factories";
+import { FactCheckRepository } from "./factcheck.repository";
+
+describe("FactCheckRepository", () => {
+  let repository: FactCheckRepository;
+
+  const mockPrisma = {
+    factCheck: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      count: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    sentence: {
+      updateMany: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FactCheckRepository, { provide: PrismaService, useValue: mockPrisma }],
+    }).compile();
+
+    repository = module.get<FactCheckRepository>(FactCheckRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("saveFactCheck", () => {
+    const userId = "user-123";
+    const factCheckId = "fc-123";
+    const title = "테스트 제목";
+    const originalText = "원본 텍스트";
+
+    it("claim은 SentenceType.CLAIM, ClaimStatus.PENDING으로 저장해야 한다", async () => {
+      const claim = createClaimResponse();
+      mockPrisma.factCheck.create.mockResolvedValue(undefined);
+
+      await repository.saveFactCheck(userId, factCheckId, title, originalText, [claim]);
+
+      expect(mockPrisma.factCheck.create).toHaveBeenCalledWith({
+        data: {
+          id: factCheckId,
+          userId,
+          title,
+          originalText,
+          checkedCount: 1,
+          sentences: {
+            create: [
+              {
+                id: claim.id,
+                type: SentenceType.CLAIM,
+                text: claim.text,
+                position: claim.position,
+                verdict: claim.verdict,
+                suggestion: claim.suggestion,
+                sources: claim.sources,
+                status: ClaimStatus.PENDING,
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    it("opinion은 SentenceType.OPINION으로 저장해야 한다", async () => {
+      const opinion = createOpinionResponse();
+      mockPrisma.factCheck.create.mockResolvedValue(undefined);
+
+      await repository.saveFactCheck(userId, factCheckId, title, originalText, [opinion]);
+
+      expect(mockPrisma.factCheck.create).toHaveBeenCalledWith({
+        data: {
+          id: factCheckId,
+          userId,
+          title,
+          originalText,
+          checkedCount: 0,
+          sentences: {
+            create: [
+              {
+                id: opinion.id,
+                type: SentenceType.OPINION,
+                text: opinion.text,
+                position: opinion.position,
+                reason: opinion.reason,
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    it("checkedCount를 claim 수로 계산해야 한다", async () => {
+      const claim1 = createClaimResponse({ id: "c1", position: 0 });
+      const opinion1 = createOpinionResponse({ id: "o1", position: 1 });
+      const claim2 = createClaimResponse({
+        id: "c2",
+        position: 2,
+        verdict: "FALSE",
+        suggestion: "수정",
+      });
+      mockPrisma.factCheck.create.mockResolvedValue(undefined);
+
+      await repository.saveFactCheck(userId, factCheckId, title, originalText, [
+        claim1,
+        opinion1,
+        claim2,
+      ]);
+
+      expect(mockPrisma.factCheck.create).toHaveBeenCalledWith({
+        data: {
+          id: factCheckId,
+          userId,
+          title,
+          originalText,
+          checkedCount: 2,
+          sentences: {
+            create: [
+              {
+                id: claim1.id,
+                type: SentenceType.CLAIM,
+                text: claim1.text,
+                position: claim1.position,
+                verdict: claim1.verdict,
+                suggestion: claim1.suggestion,
+                sources: claim1.sources,
+                status: ClaimStatus.PENDING,
+              },
+              {
+                id: opinion1.id,
+                type: SentenceType.OPINION,
+                text: opinion1.text,
+                position: opinion1.position,
+                reason: opinion1.reason,
+              },
+              {
+                id: claim2.id,
+                type: SentenceType.CLAIM,
+                text: claim2.text,
+                position: claim2.position,
+                verdict: claim2.verdict,
+                suggestion: claim2.suggestion,
+                sources: claim2.sources,
+                status: ClaimStatus.PENDING,
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    it("sources를 Prisma JSON 값으로 전달해야 한다", async () => {
+      const sources = [
+        { title: "출처1", url: "https://a.com" },
+        { title: "출처2", url: "https://b.com" },
+      ];
+      const claim = createClaimResponse({ sources });
+      mockPrisma.factCheck.create.mockResolvedValue(undefined);
+
+      await repository.saveFactCheck(userId, factCheckId, title, originalText, [claim]);
+
+      expect(mockPrisma.factCheck.create).toHaveBeenCalledWith({
+        data: {
+          id: factCheckId,
+          userId,
+          title,
+          originalText,
+          checkedCount: 1,
+          sentences: {
+            create: [
+              {
+                id: claim.id,
+                type: SentenceType.CLAIM,
+                text: claim.text,
+                position: claim.position,
+                verdict: claim.verdict,
+                suggestion: claim.suggestion,
+                sources: claim.sources,
+                status: ClaimStatus.PENDING,
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
+
+  describe("findByUserId", () => {
+    const userId = "user-123";
+
+    it("올바른 skip과 take로 페이지네이션해야 한다", async () => {
+      mockPrisma.factCheck.findMany.mockResolvedValue([]);
+      mockPrisma.factCheck.count.mockResolvedValue(0);
+
+      await repository.findByUserId(userId, 3, 10);
+
+      expect(mockPrisma.factCheck.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 20, take: 10 }),
+      );
+    });
+
+    it("createdAt desc로 정렬해야 한다", async () => {
+      mockPrisma.factCheck.findMany.mockResolvedValue([]);
+      mockPrisma.factCheck.count.mockResolvedValue(0);
+
+      await repository.findByUserId(userId, 1, 10);
+
+      expect(mockPrisma.factCheck.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ orderBy: { createdAt: "desc" } }),
+      );
+    });
+
+    it("userId로 필터링해야 한다", async () => {
+      mockPrisma.factCheck.findMany.mockResolvedValue([]);
+      mockPrisma.factCheck.count.mockResolvedValue(0);
+
+      await repository.findByUserId(userId, 1, 10);
+
+      expect(mockPrisma.factCheck.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId } }),
+      );
+      expect(mockPrisma.factCheck.count).toHaveBeenCalledWith({ where: { userId } });
+    });
+
+    it("필요한 필드만 select해야 한다", async () => {
+      mockPrisma.factCheck.findMany.mockResolvedValue([]);
+      mockPrisma.factCheck.count.mockResolvedValue(0);
+
+      await repository.findByUserId(userId, 1, 10);
+
+      expect(mockPrisma.factCheck.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: {
+            id: true,
+            title: true,
+            originalText: true,
+            checkedCount: true,
+            createdAt: true,
+          },
+        }),
+      );
+    });
+
+    it("items와 total을 반환해야 한다", async () => {
+      const mockItems = [
+        {
+          id: "fc-1",
+          title: "제목",
+          originalText: "텍스트",
+          checkedCount: 2,
+          createdAt: new Date(),
+        },
+      ];
+      mockPrisma.factCheck.findMany.mockResolvedValue(mockItems);
+      mockPrisma.factCheck.count.mockResolvedValue(5);
+
+      const result = await repository.findByUserId(userId, 1, 10);
+
+      expect(result).toEqual({ items: mockItems, total: 5 });
+    });
+  });
+
+  describe("findById", () => {
+    const userId = "user-123";
+    const factCheckId = "fc-123";
+
+    it("userId와 factCheckId로 조회해야 한다", async () => {
+      mockPrisma.factCheck.findFirst.mockResolvedValue(null);
+
+      await repository.findById(userId, factCheckId);
+
+      expect(mockPrisma.factCheck.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: factCheckId, userId },
+        }),
+      );
+    });
+
+    it("sentences를 position 순으로 include해야 한다", async () => {
+      mockPrisma.factCheck.findFirst.mockResolvedValue(null);
+
+      await repository.findById(userId, factCheckId);
+
+      expect(mockPrisma.factCheck.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: {
+            sentences: { orderBy: { position: "asc" } },
+          },
+        }),
+      );
+    });
+
+    it("결과가 없으면 null을 반환해야 한다", async () => {
+      mockPrisma.factCheck.findFirst.mockResolvedValue(null);
+
+      const result = await repository.findById(userId, factCheckId);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteById", () => {
+    const userId = "user-123";
+    const factCheckId = "fc-123";
+
+    it("userId와 factCheckId로 deleteMany를 호출해야 한다", async () => {
+      mockPrisma.factCheck.deleteMany.mockResolvedValue({ count: 1 });
+
+      await repository.deleteById(userId, factCheckId);
+
+      expect(mockPrisma.factCheck.deleteMany).toHaveBeenCalledWith({
+        where: { id: factCheckId, userId },
+      });
+    });
+
+    it("삭제 count > 0이면 true를 반환해야 한다", async () => {
+      mockPrisma.factCheck.deleteMany.mockResolvedValue({ count: 1 });
+
+      const result = await repository.deleteById(userId, factCheckId);
+
+      expect(result).toBe(true);
+    });
+
+    it("삭제 count === 0이면 false를 반환해야 한다", async () => {
+      mockPrisma.factCheck.deleteMany.mockResolvedValue({ count: 0 });
+
+      const result = await repository.deleteById(userId, factCheckId);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("updateClaimStatus", () => {
+    const userId = "user-123";
+    const factCheckId = "fc-123";
+    const claimId = "claim-1";
+
+    it("CLAIM 타입 + factCheck 소유자 조건으로 updateMany를 호출해야 한다", async () => {
+      mockPrisma.sentence.updateMany.mockResolvedValue({ count: 1 });
+
+      await repository.updateClaimStatus(userId, factCheckId, claimId, ClaimStatus.APPLIED);
+
+      expect(mockPrisma.sentence.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: claimId,
+          factCheck: { id: factCheckId, userId },
+          type: SentenceType.CLAIM,
+        },
+        data: { status: ClaimStatus.APPLIED },
+      });
+    });
+
+    it("변경 count > 0이면 true를 반환해야 한다", async () => {
+      mockPrisma.sentence.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await repository.updateClaimStatus(
+        userId,
+        factCheckId,
+        claimId,
+        ClaimStatus.IGNORED,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it("변경 count === 0이면 false를 반환해야 한다", async () => {
+      mockPrisma.sentence.updateMany.mockResolvedValue({ count: 0 });
+
+      const result = await repository.updateClaimStatus(
+        userId,
+        factCheckId,
+        claimId,
+        ClaimStatus.APPLIED,
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/factcheck/testing/factories.ts
+++ b/src/factcheck/testing/factories.ts
@@ -1,0 +1,71 @@
+import type { FactCheck, Sentence } from "@prisma/client";
+import type { ClaimSentenceResponse, OpinionSentenceResponse } from "../dto/factcheck-response.dto";
+
+export type FactCheckWithSentences = FactCheck & { sentences: Sentence[] };
+
+export const createDbClaim = (overrides?: Partial<Sentence>): Sentence => ({
+  id: "1",
+  type: "CLAIM",
+  text: "검증 문장",
+  position: 0,
+  verdict: "TRUE",
+  suggestion: null,
+  sources: [{ title: "출처", url: "https://example.com" }],
+  status: "PENDING",
+  reason: null,
+  factCheckId: "fc-123",
+  ...overrides,
+});
+
+export const createDbOpinion = (overrides?: Partial<Sentence>): Sentence => ({
+  id: "2",
+  type: "OPINION",
+  text: "의견 문장",
+  position: 0,
+  verdict: null,
+  suggestion: null,
+  sources: null,
+  status: null,
+  reason: "주관적 표현",
+  factCheckId: "fc-123",
+  ...overrides,
+});
+
+export const createDbFactCheck = (
+  overrides?: Partial<FactCheckWithSentences>,
+): FactCheckWithSentences => ({
+  id: "fc-123",
+  title: "제목",
+  originalText: "텍스트",
+  checkedCount: 0,
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+  userId: "user-123",
+  sentences: [],
+  ...overrides,
+});
+
+export const createClaimResponse = (
+  overrides?: Partial<ClaimSentenceResponse>,
+): ClaimSentenceResponse => ({
+  id: "claim-1",
+  type: "claim",
+  text: "검증 가능한 문장",
+  position: 0,
+  verdict: "TRUE",
+  suggestion: null,
+  sources: [{ title: "출처", url: "https://example.com" }],
+  status: "pending",
+  ...overrides,
+});
+
+export const createOpinionResponse = (
+  overrides?: Partial<OpinionSentenceResponse>,
+): OpinionSentenceResponse => ({
+  id: "opinion-1",
+  type: "opinion",
+  text: "의견 문장",
+  position: 1,
+  reason: "주관적 표현",
+  ...overrides,
+});

--- a/src/mcp/mcp.service.spec.ts
+++ b/src/mcp/mcp.service.spec.ts
@@ -16,7 +16,20 @@ jest.mock("uuid", () => ({
 
 describe("McpService", () => {
   let service: McpService;
-  let mockAxiosPost: jest.Mock;
+
+  const mockConfigService = {
+    getOrThrow: jest.fn().mockReturnValue("http://localhost:8000"),
+  };
+
+  const mockHttpService = {
+    axiosRef: {
+      post: jest.fn(),
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
+      },
+    },
+  };
 
   const mockMcpResponse: McpResponse = {
     title: "테스트 제목",
@@ -43,29 +56,16 @@ describe("McpService", () => {
   };
 
   beforeEach(async () => {
-    mockAxiosPost = jest.fn();
-
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         McpService,
         {
           provide: ConfigService,
-          useValue: {
-            getOrThrow: jest.fn().mockReturnValue("http://localhost:8000"),
-          },
+          useValue: mockConfigService,
         },
         {
           provide: HttpService,
-          useValue: {
-            axiosRef: {
-              post: mockAxiosPost,
-              // axios-retry가 초기화 시 interceptors에 접근
-              interceptors: {
-                request: { use: jest.fn() },
-                response: { use: jest.fn() },
-              },
-            },
-          },
+          useValue: mockHttpService,
         },
       ],
     }).compile();
@@ -73,13 +73,9 @@ describe("McpService", () => {
     service = module.get<McpService>(McpService);
   });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   describe("analyze", () => {
     it("정상 응답 시 McpResponse를 반환해야 한다", async () => {
-      mockAxiosPost.mockResolvedValue({
+      mockHttpService.axiosRef.post.mockResolvedValue({
         data: {
           jsonrpc: "2.0",
           id: "test-id",
@@ -101,23 +97,26 @@ describe("McpService", () => {
       expect(result.sentences[0].type).toBe("claim");
       expect(result.sentences[1].type).toBe("opinion");
 
-      expect(mockAxiosPost).toHaveBeenCalledWith("http://localhost:8000/api/factcheck", {
-        jsonrpc: "2.0",
-        id: "test-uuid",
-        method: "tools/call",
-        params: {
-          name: "factcheck",
-          arguments: {
-            text: "테스트 텍스트",
-            whitelist: [],
-            blacklist: [],
+      expect(mockHttpService.axiosRef.post).toHaveBeenCalledWith(
+        "http://localhost:8000/api/factcheck",
+        {
+          jsonrpc: "2.0",
+          id: "test-uuid",
+          method: "tools/call",
+          params: {
+            name: "factcheck",
+            arguments: {
+              text: "테스트 텍스트",
+              whitelist: [],
+              blacklist: [],
+            },
           },
         },
-      });
+      );
     });
 
     it("요청 형식이 요구사항과 일치해야 한다 (whitelist, blacklist 포함)", async () => {
-      mockAxiosPost.mockResolvedValue({
+      mockHttpService.axiosRef.post.mockResolvedValue({
         data: {
           jsonrpc: "2.0",
           id: "test-id",
@@ -133,7 +132,7 @@ describe("McpService", () => {
 
       await service.analyze(text, filters);
 
-      expect(mockAxiosPost).toHaveBeenCalledWith(
+      expect(mockHttpService.axiosRef.post).toHaveBeenCalledWith(
         expect.stringContaining("/api/factcheck"),
         expect.objectContaining({
           jsonrpc: "2.0",
@@ -157,14 +156,14 @@ describe("McpService", () => {
         response: { status: 500, statusText: "Internal Server Error" },
         isAxiosError: true,
       });
-      mockAxiosPost.mockRejectedValue(axiosError);
+      mockHttpService.axiosRef.post.mockRejectedValue(axiosError);
 
       await expect(service.analyze("테스트 텍스트")).rejects.toThrow(BadGatewayException);
       await expect(service.analyze("테스트 텍스트")).rejects.toThrow("MCP_ERROR");
     });
 
     it("네트워크 오류 시 BadGatewayException을 던져야 한다", async () => {
-      mockAxiosPost.mockRejectedValue(new Error("Network error"));
+      mockHttpService.axiosRef.post.mockRejectedValue(new Error("Network error"));
 
       await expect(service.analyze("테스트 텍스트")).rejects.toThrow(BadGatewayException);
     });
@@ -172,7 +171,7 @@ describe("McpService", () => {
     it("타임아웃 시 GatewayTimeoutException을 던져야 한다", async () => {
       const axiosError = new AxiosError("timeout of 30000ms exceeded");
       axiosError.code = "ECONNABORTED";
-      mockAxiosPost.mockRejectedValue(axiosError);
+      mockHttpService.axiosRef.post.mockRejectedValue(axiosError);
 
       await expect(service.analyze("테스트 텍스트")).rejects.toThrow(GatewayTimeoutException);
       await expect(service.analyze("테스트 텍스트")).rejects.toThrow("MCP_TIMEOUT");
@@ -181,7 +180,7 @@ describe("McpService", () => {
     it("연결 실패 시 ServiceUnavailableException을 던져야 한다", async () => {
       const axiosError = new AxiosError("connect ECONNREFUSED");
       axiosError.code = "ECONNREFUSED";
-      mockAxiosPost.mockRejectedValue(axiosError);
+      mockHttpService.axiosRef.post.mockRejectedValue(axiosError);
 
       await expect(service.analyze("테스트 텍스트")).rejects.toThrow(ServiceUnavailableException);
       await expect(service.analyze("테스트 텍스트")).rejects.toThrow("MCP_UNAVAILABLE");

--- a/src/settings/settings.integration.spec.ts
+++ b/src/settings/settings.integration.spec.ts
@@ -1,0 +1,306 @@
+import { ConflictException } from "@nestjs/common";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ListType, Prisma } from "@prisma/client";
+import type { AuthenticatedUser } from "../auth/types/auth.types";
+import { ERROR_CODES } from "../common/constants/error-codes";
+import type { CreateDomainDto } from "./dto/create-domain.dto";
+import { DomainFilterRepository } from "./repositories/domain-filter.repository";
+import { SettingsController } from "./settings.controller";
+import { SettingsService } from "./settings.service";
+
+const createUser = (overrides?: Partial<AuthenticatedUser>): AuthenticatedUser => ({
+  userId: "user-123",
+  email: "test@example.com",
+  isGuest: false as const,
+  ...overrides,
+});
+
+const createDomainDto = (domain = "example.com"): CreateDomainDto => ({
+  domain,
+});
+
+describe("Settings Integration (Controller + Service)", () => {
+  let controller: SettingsController;
+
+  const mockRepository = {
+    findFiltersByUserId: jest.fn(),
+    findFiltersByType: jest.fn(),
+    findFilter: jest.fn(),
+    createFilter: jest.fn(),
+    deleteFilter: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SettingsController],
+      providers: [SettingsService, { provide: DomainFilterRepository, useValue: mockRepository }],
+    }).compile();
+
+    controller = module.get<SettingsController>(SettingsController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getSettings", () => {
+    it("화이트리스트와 블랙리스트를 분류하여 반환해야 한다", async () => {
+      const user = createUser();
+      mockRepository.findFiltersByUserId.mockResolvedValue([
+        { domain: "trusted.com", listType: ListType.WHITE },
+        { domain: "bad.com", listType: ListType.BLACK },
+        { domain: "good.com", listType: ListType.WHITE },
+      ]);
+
+      const result = await controller.getSettings(user);
+
+      expect(result).toEqual({
+        whitelist: ["trusted.com", "good.com"],
+        blacklist: ["bad.com"],
+      });
+      expect(mockRepository.findFiltersByUserId).toHaveBeenCalledWith("user-123");
+    });
+
+    it("필터가 없으면 빈 배열을 반환해야 한다", async () => {
+      const user = createUser();
+      mockRepository.findFiltersByUserId.mockResolvedValue([]);
+
+      const result = await controller.getSettings(user);
+
+      expect(result).toEqual({
+        whitelist: [],
+        blacklist: [],
+      });
+    });
+
+    it("화이트리스트만 있을 때 블랙리스트는 빈 배열이어야 한다", async () => {
+      const user = createUser();
+      mockRepository.findFiltersByUserId.mockResolvedValue([
+        { domain: "trusted.com", listType: ListType.WHITE },
+      ]);
+
+      const result = await controller.getSettings(user);
+
+      expect(result).toEqual({
+        whitelist: ["trusted.com"],
+        blacklist: [],
+      });
+    });
+  });
+
+  describe("addWhitelist", () => {
+    it("도메인을 화이트리스트에 추가하고 목록을 반환해야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("trusted.com");
+      mockRepository.findFilter.mockResolvedValue(null);
+      mockRepository.createFilter.mockResolvedValue({
+        id: 1,
+        domain: "trusted.com",
+        listType: ListType.WHITE,
+        userId: "user-123",
+      });
+      mockRepository.findFiltersByType.mockResolvedValue([{ domain: "trusted.com" }]);
+
+      const result = await controller.addWhitelist(user, dto);
+
+      expect(result).toEqual({ whitelist: ["trusted.com"] });
+      expect(mockRepository.findFilter).toHaveBeenCalledWith(
+        "user-123",
+        "trusted.com",
+        ListType.BLACK,
+      );
+      expect(mockRepository.createFilter).toHaveBeenCalledWith(
+        "user-123",
+        "trusted.com",
+        ListType.WHITE,
+      );
+    });
+
+    it("블랙리스트에 동일 도메인이 있으면 ConflictException(DOMAIN_CONFLICT)을 던져야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("conflict.com");
+      mockRepository.findFilter.mockResolvedValue({
+        id: 1,
+        domain: "conflict.com",
+        listType: ListType.BLACK,
+        userId: "user-123",
+      });
+
+      const promise = controller.addWhitelist(user, dto);
+      await expect(promise).rejects.toThrow(new ConflictException(ERROR_CODES.DOMAIN_CONFLICT));
+      expect(mockRepository.createFilter).not.toHaveBeenCalled();
+    });
+
+    it("이미 화이트리스트에 동일 도메인이 있으면 ConflictException(DUPLICATE_DOMAIN)을 던져야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("duplicate.com");
+      mockRepository.findFilter.mockResolvedValue(null);
+      const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "5.0.0",
+      });
+      mockRepository.createFilter.mockRejectedValue(prismaError);
+
+      const promise = controller.addWhitelist(user, dto);
+      await expect(promise).rejects.toThrow(new ConflictException(ERROR_CODES.DUPLICATE_DOMAIN));
+    });
+
+    it("PrismaClientKnownRequestError이지만 P2002가 아닌 에러는 그대로 rethrow해야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("fk-error.com");
+      mockRepository.findFilter.mockResolvedValue(null);
+      const prismaError = new Prisma.PrismaClientKnownRequestError("FK constraint failed", {
+        code: "P2003",
+        clientVersion: "5.0.0",
+      });
+      mockRepository.createFilter.mockRejectedValue(prismaError);
+
+      const promise = controller.addWhitelist(user, dto);
+      await expect(promise).rejects.toThrow(Prisma.PrismaClientKnownRequestError);
+      await expect(controller.addWhitelist(user, dto)).rejects.not.toThrow(ConflictException);
+    });
+
+    it("Prisma 이외의 에러는 그대로 rethrow해야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("error.com");
+      mockRepository.findFilter.mockResolvedValue(null);
+      const unknownError = new Error("DB connection lost");
+      mockRepository.createFilter.mockRejectedValue(unknownError);
+
+      await expect(controller.addWhitelist(user, dto)).rejects.toThrow("DB connection lost");
+    });
+  });
+
+  describe("addBlacklist", () => {
+    it("도메인을 블랙리스트에 추가하고 목록을 반환해야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("bad.com");
+      mockRepository.findFilter.mockResolvedValue(null);
+      mockRepository.createFilter.mockResolvedValue({
+        id: 2,
+        domain: "bad.com",
+        listType: ListType.BLACK,
+        userId: "user-123",
+      });
+      mockRepository.findFiltersByType.mockResolvedValue([{ domain: "bad.com" }]);
+
+      const result = await controller.addBlacklist(user, dto);
+
+      expect(result).toEqual({ blacklist: ["bad.com"] });
+      expect(mockRepository.findFilter).toHaveBeenCalledWith("user-123", "bad.com", ListType.WHITE);
+      expect(mockRepository.createFilter).toHaveBeenCalledWith(
+        "user-123",
+        "bad.com",
+        ListType.BLACK,
+      );
+    });
+
+    it("화이트리스트에 동일 도메인이 있으면 ConflictException(DOMAIN_CONFLICT)을 던져야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("conflict.com");
+      mockRepository.findFilter.mockResolvedValue({
+        id: 1,
+        domain: "conflict.com",
+        listType: ListType.WHITE,
+        userId: "user-123",
+      });
+
+      const promise = controller.addBlacklist(user, dto);
+      await expect(promise).rejects.toThrow(new ConflictException(ERROR_CODES.DOMAIN_CONFLICT));
+      expect(mockRepository.createFilter).not.toHaveBeenCalled();
+    });
+
+    it("이미 블랙리스트에 동일 도메인이 있으면 ConflictException(DUPLICATE_DOMAIN)을 던져야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("duplicate.com");
+      mockRepository.findFilter.mockResolvedValue(null);
+      const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "5.0.0",
+      });
+      mockRepository.createFilter.mockRejectedValue(prismaError);
+
+      const promise = controller.addBlacklist(user, dto);
+      await expect(promise).rejects.toThrow(new ConflictException(ERROR_CODES.DUPLICATE_DOMAIN));
+    });
+
+    it("PrismaClientKnownRequestError이지만 P2002가 아닌 에러는 그대로 rethrow해야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("fk-error.com");
+      mockRepository.findFilter.mockResolvedValue(null);
+      const prismaError = new Prisma.PrismaClientKnownRequestError("FK constraint failed", {
+        code: "P2003",
+        clientVersion: "5.0.0",
+      });
+      mockRepository.createFilter.mockRejectedValue(prismaError);
+
+      const promise = controller.addBlacklist(user, dto);
+      await expect(promise).rejects.toThrow(Prisma.PrismaClientKnownRequestError);
+      await expect(controller.addBlacklist(user, dto)).rejects.not.toThrow(ConflictException);
+    });
+
+    it("Prisma 이외의 에러는 그대로 rethrow해야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("error.com");
+      mockRepository.findFilter.mockResolvedValue(null);
+      const unknownError = new Error("DB connection lost");
+      mockRepository.createFilter.mockRejectedValue(unknownError);
+
+      await expect(controller.addBlacklist(user, dto)).rejects.toThrow("DB connection lost");
+    });
+  });
+
+  describe("deleteWhitelist", () => {
+    it("도메인을 화이트리스트에서 삭제하고 남은 목록을 반환해야 한다", async () => {
+      const user = createUser();
+      mockRepository.deleteFilter.mockResolvedValue({ count: 1 });
+      mockRepository.findFiltersByType.mockResolvedValue([{ domain: "remaining.com" }]);
+
+      const result = await controller.deleteWhitelist(user, "removed.com");
+
+      expect(result).toEqual({ whitelist: ["remaining.com"] });
+      expect(mockRepository.deleteFilter).toHaveBeenCalledWith(
+        "user-123",
+        "removed.com",
+        ListType.WHITE,
+      );
+    });
+
+    it("마지막 도메인을 삭제하면 빈 배열을 반환해야 한다", async () => {
+      const user = createUser();
+      mockRepository.deleteFilter.mockResolvedValue({ count: 1 });
+      mockRepository.findFiltersByType.mockResolvedValue([]);
+
+      const result = await controller.deleteWhitelist(user, "last.com");
+
+      expect(result).toEqual({ whitelist: [] });
+    });
+  });
+
+  describe("deleteBlacklist", () => {
+    it("도메인을 블랙리스트에서 삭제하고 남은 목록을 반환해야 한다", async () => {
+      const user = createUser();
+      mockRepository.deleteFilter.mockResolvedValue({ count: 1 });
+      mockRepository.findFiltersByType.mockResolvedValue([{ domain: "still-bad.com" }]);
+
+      const result = await controller.deleteBlacklist(user, "removed-bad.com");
+
+      expect(result).toEqual({ blacklist: ["still-bad.com"] });
+      expect(mockRepository.deleteFilter).toHaveBeenCalledWith(
+        "user-123",
+        "removed-bad.com",
+        ListType.BLACK,
+      );
+    });
+
+    it("마지막 도메인을 삭제하면 빈 배열을 반환해야 한다", async () => {
+      const user = createUser();
+      mockRepository.deleteFilter.mockResolvedValue({ count: 1 });
+      mockRepository.findFiltersByType.mockResolvedValue([]);
+
+      const result = await controller.deleteBlacklist(user, "last-bad.com");
+
+      expect(result).toEqual({ blacklist: [] });
+    });
+  });
+});

--- a/src/settings/settings.integration.spec.ts
+++ b/src/settings/settings.integration.spec.ts
@@ -116,6 +116,26 @@ describe("Settings Integration (Controller + Service)", () => {
       );
     });
 
+    it("복수 도메인이 존재할 때 전체 목록을 반환해야 한다", async () => {
+      const user = createUser();
+      const dto = createDomainDto("new-domain.com");
+      mockRepository.findFilter.mockResolvedValue(null);
+      mockRepository.createFilter.mockResolvedValue({
+        id: 3,
+        domain: "new-domain.com",
+        listType: ListType.WHITE,
+        userId: "user-123",
+      });
+      mockRepository.findFiltersByType.mockResolvedValue([
+        { domain: "existing.com" },
+        { domain: "new-domain.com" },
+      ]);
+
+      const result = await controller.addWhitelist(user, dto);
+
+      expect(result).toEqual({ whitelist: ["existing.com", "new-domain.com"] });
+    });
+
     it("블랙리스트에 동일 도메인이 있으면 ConflictException(DOMAIN_CONFLICT)을 던져야 한다", async () => {
       const user = createUser();
       const dto = createDomainDto("conflict.com");
@@ -172,6 +192,8 @@ describe("Settings Integration (Controller + Service)", () => {
   });
 
   describe("addBlacklist", () => {
+    // 에러 분기(P2002, rethrow)는 addWhitelist에서 검증 — addFilter 공통 로직이므로 ListType 무관
+
     it("도메인을 블랙리스트에 추가하고 목록을 반환해야 한다", async () => {
       const user = createUser();
       const dto = createDomainDto("bad.com");
@@ -209,45 +231,6 @@ describe("Settings Integration (Controller + Service)", () => {
       await expect(promise).rejects.toThrow(new ConflictException(ERROR_CODES.DOMAIN_CONFLICT));
       expect(mockRepository.createFilter).not.toHaveBeenCalled();
     });
-
-    it("이미 블랙리스트에 동일 도메인이 있으면 ConflictException(DUPLICATE_DOMAIN)을 던져야 한다", async () => {
-      const user = createUser();
-      const dto = createDomainDto("duplicate.com");
-      mockRepository.findFilter.mockResolvedValue(null);
-      const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
-        code: "P2002",
-        clientVersion: "5.0.0",
-      });
-      mockRepository.createFilter.mockRejectedValue(prismaError);
-
-      const promise = controller.addBlacklist(user, dto);
-      await expect(promise).rejects.toThrow(new ConflictException(ERROR_CODES.DUPLICATE_DOMAIN));
-    });
-
-    it("PrismaClientKnownRequestError이지만 P2002가 아닌 에러는 그대로 rethrow해야 한다", async () => {
-      const user = createUser();
-      const dto = createDomainDto("fk-error.com");
-      mockRepository.findFilter.mockResolvedValue(null);
-      const prismaError = new Prisma.PrismaClientKnownRequestError("FK constraint failed", {
-        code: "P2003",
-        clientVersion: "5.0.0",
-      });
-      mockRepository.createFilter.mockRejectedValue(prismaError);
-
-      const promise = controller.addBlacklist(user, dto);
-      await expect(promise).rejects.toThrow(Prisma.PrismaClientKnownRequestError);
-      await expect(controller.addBlacklist(user, dto)).rejects.not.toThrow(ConflictException);
-    });
-
-    it("Prisma 이외의 에러는 그대로 rethrow해야 한다", async () => {
-      const user = createUser();
-      const dto = createDomainDto("error.com");
-      mockRepository.findFilter.mockResolvedValue(null);
-      const unknownError = new Error("DB connection lost");
-      mockRepository.createFilter.mockRejectedValue(unknownError);
-
-      await expect(controller.addBlacklist(user, dto)).rejects.toThrow("DB connection lost");
-    });
   });
 
   describe("deleteWhitelist", () => {
@@ -274,6 +257,17 @@ describe("Settings Integration (Controller + Service)", () => {
       const result = await controller.deleteWhitelist(user, "last.com");
 
       expect(result).toEqual({ whitelist: [] });
+    });
+
+    // deleteMany는 존재하지 않는 도메인도 {count: 0}을 반환 — 멱등성 보장 검증
+    it("존재하지 않는 도메인 삭제 시 에러 없이 현재 목록을 반환해야 한다", async () => {
+      const user = createUser();
+      mockRepository.deleteFilter.mockResolvedValue({ count: 0 });
+      mockRepository.findFiltersByType.mockResolvedValue([{ domain: "existing.com" }]);
+
+      const result = await controller.deleteWhitelist(user, "non-existent.com");
+
+      expect(result).toEqual({ whitelist: ["existing.com"] });
     });
   });
 

--- a/src/settings/settings.service.spec.ts
+++ b/src/settings/settings.service.spec.ts
@@ -1,0 +1,240 @@
+import { ConflictException } from "@nestjs/common";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ListType, Prisma } from "@prisma/client";
+import { ERROR_CODES } from "../common/constants/error-codes";
+import { DomainFilterRepository } from "./repositories/domain-filter.repository";
+import { SettingsService } from "./settings.service";
+
+interface MockFilter {
+  domain: string;
+  listType: ListType;
+}
+
+const TEST_USER_ID = "user-123";
+
+const createFilter = (overrides?: Partial<MockFilter>): MockFilter => ({
+  domain: "example.com",
+  listType: ListType.WHITE,
+  ...overrides,
+});
+
+describe("SettingsService", () => {
+  let service: SettingsService;
+
+  const mockRepository = {
+    findFiltersByUserId: jest.fn(),
+    findFiltersByType: jest.fn(),
+    findFilter: jest.fn(),
+    createFilter: jest.fn(),
+    deleteFilter: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SettingsService, { provide: DomainFilterRepository, useValue: mockRepository }],
+    }).compile();
+
+    service = module.get<SettingsService>(SettingsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getSettings", () => {
+    it("필터를 화이트리스트와 블랙리스트로 분류하여 반환해야 한다", async () => {
+      mockRepository.findFiltersByUserId.mockResolvedValue([
+        createFilter({ domain: "good.com", listType: ListType.WHITE }),
+        createFilter({ domain: "bad.com", listType: ListType.BLACK }),
+        createFilter({ domain: "trusted.com", listType: ListType.WHITE }),
+      ]);
+
+      const result = await service.getSettings(TEST_USER_ID);
+
+      expect(result).toEqual({
+        whitelist: ["good.com", "trusted.com"],
+        blacklist: ["bad.com"],
+      });
+    });
+
+    it("필터가 없으면 빈 배열을 반환해야 한다", async () => {
+      mockRepository.findFiltersByUserId.mockResolvedValue([]);
+
+      const result = await service.getSettings(TEST_USER_ID);
+
+      expect(result).toEqual({
+        whitelist: [],
+        blacklist: [],
+      });
+    });
+  });
+
+  describe("addWhitelist", () => {
+    it("도메인을 화이트리스트에 추가하고 whitelist 키로 반환해야 한다", async () => {
+      mockRepository.findFilter.mockResolvedValue(null);
+      mockRepository.createFilter.mockResolvedValue(undefined);
+      mockRepository.findFiltersByType.mockResolvedValue([{ domain: "added.com" }]);
+
+      const result = await service.addWhitelist(TEST_USER_ID, "added.com");
+
+      expect(result).toEqual({ whitelist: ["added.com"] });
+      expect(mockRepository.createFilter).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        "added.com",
+        ListType.WHITE,
+      );
+    });
+
+    it("블랙리스트에 동일 도메인이 있으면 DOMAIN_CONFLICT를 던져야 한다", async () => {
+      mockRepository.findFilter.mockResolvedValue(
+        createFilter({ domain: "conflict.com", listType: ListType.BLACK }),
+      );
+
+      await expect(service.addWhitelist(TEST_USER_ID, "conflict.com")).rejects.toThrow(
+        new ConflictException(ERROR_CODES.DOMAIN_CONFLICT),
+      );
+      expect(mockRepository.findFilter).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        "conflict.com",
+        ListType.BLACK,
+      );
+      expect(mockRepository.createFilter).not.toHaveBeenCalled();
+    });
+
+    it("P2002 유니크 제약 위반 시 DUPLICATE_DOMAIN을 던져야 한다", async () => {
+      mockRepository.findFilter.mockResolvedValue(null);
+      mockRepository.createFilter.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+          code: "P2002",
+          clientVersion: "5.0.0",
+        }),
+      );
+
+      await expect(service.addWhitelist(TEST_USER_ID, "dup.com")).rejects.toThrow(
+        new ConflictException(ERROR_CODES.DUPLICATE_DOMAIN),
+      );
+    });
+
+    it("P2002가 아닌 PrismaClientKnownRequestError는 그대로 rethrow해야 한다", async () => {
+      mockRepository.findFilter.mockResolvedValue(null);
+      const prismaError = new Prisma.PrismaClientKnownRequestError("FK constraint failed", {
+        code: "P2003",
+        clientVersion: "5.0.0",
+      });
+      mockRepository.createFilter.mockRejectedValue(prismaError);
+
+      await expect(service.addWhitelist(TEST_USER_ID, "fk.com")).rejects.toThrow(
+        Prisma.PrismaClientKnownRequestError,
+      );
+      await expect(service.addWhitelist(TEST_USER_ID, "fk.com")).rejects.not.toThrow(
+        ConflictException,
+      );
+    });
+
+    it("Prisma 이외의 에러는 그대로 rethrow해야 한다", async () => {
+      mockRepository.findFilter.mockResolvedValue(null);
+      mockRepository.createFilter.mockRejectedValue(new Error("Connection lost"));
+
+      await expect(service.addWhitelist(TEST_USER_ID, "err.com")).rejects.toThrow(
+        "Connection lost",
+      );
+    });
+  });
+
+  describe("addBlacklist", () => {
+    it("도메인을 블랙리스트에 추가하고 blacklist 키로 반환해야 한다", async () => {
+      mockRepository.findFilter.mockResolvedValue(null);
+      mockRepository.createFilter.mockResolvedValue(undefined);
+      mockRepository.findFiltersByType.mockResolvedValue([{ domain: "blocked.com" }]);
+
+      const result = await service.addBlacklist(TEST_USER_ID, "blocked.com");
+
+      expect(result).toEqual({ blacklist: ["blocked.com"] });
+      expect(mockRepository.createFilter).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        "blocked.com",
+        ListType.BLACK,
+      );
+    });
+
+    it("화이트리스트에 동일 도메인이 있으면 DOMAIN_CONFLICT를 던져야 한다", async () => {
+      mockRepository.findFilter.mockResolvedValue(
+        createFilter({ domain: "conflict.com", listType: ListType.WHITE }),
+      );
+
+      await expect(service.addBlacklist(TEST_USER_ID, "conflict.com")).rejects.toThrow(
+        new ConflictException(ERROR_CODES.DOMAIN_CONFLICT),
+      );
+      expect(mockRepository.findFilter).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        "conflict.com",
+        ListType.WHITE,
+      );
+      expect(mockRepository.createFilter).not.toHaveBeenCalled();
+    });
+
+    it("P2002 유니크 제약 위반 시 DUPLICATE_DOMAIN을 던져야 한다", async () => {
+      mockRepository.findFilter.mockResolvedValue(null);
+      mockRepository.createFilter.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+          code: "P2002",
+          clientVersion: "5.0.0",
+        }),
+      );
+
+      await expect(service.addBlacklist(TEST_USER_ID, "dup.com")).rejects.toThrow(
+        new ConflictException(ERROR_CODES.DUPLICATE_DOMAIN),
+      );
+    });
+  });
+
+  describe("deleteWhitelist", () => {
+    it("도메인을 삭제하고 남은 화이트리스트를 whitelist 키로 반환해야 한다", async () => {
+      mockRepository.deleteFilter.mockResolvedValue({ count: 1 });
+      mockRepository.findFiltersByType.mockResolvedValue([{ domain: "remaining.com" }]);
+
+      const result = await service.deleteWhitelist(TEST_USER_ID, "removed.com");
+
+      expect(result).toEqual({ whitelist: ["remaining.com"] });
+      expect(mockRepository.deleteFilter).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        "removed.com",
+        ListType.WHITE,
+      );
+    });
+
+    it("마지막 도메인을 삭제하면 빈 배열을 반환해야 한다", async () => {
+      mockRepository.deleteFilter.mockResolvedValue({ count: 1 });
+      mockRepository.findFiltersByType.mockResolvedValue([]);
+
+      const result = await service.deleteWhitelist(TEST_USER_ID, "last.com");
+
+      expect(result).toEqual({ whitelist: [] });
+    });
+  });
+
+  describe("deleteBlacklist", () => {
+    it("도메인을 삭제하고 남은 블랙리스트를 blacklist 키로 반환해야 한다", async () => {
+      mockRepository.deleteFilter.mockResolvedValue({ count: 1 });
+      mockRepository.findFiltersByType.mockResolvedValue([{ domain: "still-bad.com" }]);
+
+      const result = await service.deleteBlacklist(TEST_USER_ID, "removed-bad.com");
+
+      expect(result).toEqual({ blacklist: ["still-bad.com"] });
+      expect(mockRepository.deleteFilter).toHaveBeenCalledWith(
+        TEST_USER_ID,
+        "removed-bad.com",
+        ListType.BLACK,
+      );
+    });
+
+    it("마지막 도메인을 삭제하면 빈 배열을 반환해야 한다", async () => {
+      mockRepository.deleteFilter.mockResolvedValue({ count: 1 });
+      mockRepository.findFiltersByType.mockResolvedValue([]);
+
+      const result = await service.deleteBlacklist(TEST_USER_ID, "last-bad.com");
+
+      expect(result).toEqual({ blacklist: [] });
+    });
+  });
+});


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Closes #23

## 🛠️ 작업 내용 (Description)
- AS-IS: E2E 테스트 5개 + 서비스 단위 테스트 일부만 존재. 통합 테스트 0개, Guard/Strategy/Repository/Settings 단위 테스트 0개. "모래시계" 형태의 커버리지.
- TO-BE: 테스트 트로피 전략 기반으로 통합 테스트 4개 모듈 + 단위 테스트 8개 모듈 추가. **19 suites, 248 tests** 전부 통과.

### 추가된 테스트

**단위 테스트**
- Auth: JwtAuthGuard, JwtStrategy, SharedSecretGuard, IP 해싱, 게스트 저장소
- FactCheck: Service 보강, Repository, claim 상태 변경
- ApiKeys: Service (생성/검증/삭제/캐시)
- Settings: Service (도메인 추가/삭제/충돌 검사)
- Common: AllExceptionsFilter (HTTP/비HTTP/Validation 에러 분류)

**통합 테스트 (Controller + Service)**
- Auth: exchangeToken, refresh, logout, me, guest
- FactCheck: 팩트체크 생성(인증/게스트), 목록 조회, 상세 조회, 삭제, apply/ignore
- ApiKeys: 키 생성/목록 조회/삭제/검증, Redis 캐시 연동
- Settings: 화이트/블랙리스트 CRUD, 도메인 충돌 검사, DELETE 멱등성

**테스트 인프라**
- Mock 팩토리 공유 모듈 분리 (`factcheck/testing/factories.ts`)

---

### 테스트 우선순위 — 위험도 기반 모듈 순서 결정

보안 민감도와 비즈니스 핵심도를 기준으로 3단계로 나눴습니다.

**1차 기준 — 보안 영향도**

인증·보안 모듈이 뚫리면 전체 시스템이 위험하므로 가장 먼저 테스트했습니다.

| 순서 | 모듈 | 근거 |
|------|------|------|
| 1 | Auth (Guard, Util, Strategy) | JWT 검증, 게스트/사용자 판별, IP 해싱 — 잘못되면 권한 우회 |
| 2 | ApiKeys Service | API 키 해싱, 캐시 검증 — 잘못되면 서버 간 인증 우회 |
| 3 | AllExceptionsFilter | 에러 응답에 내부 정보 노출 방지 |

**2차 기준 — 코드 경로 복잡도**

같은 모듈 안에서는 분기가 많은 레이어를 먼저 테스트했습니다.

| 레이어 | 평균 분기 수 | 테스트 순서 |
|--------|-----------|-----------|
| Service | 8-12개 | 먼저 |
| Guard/Strategy | 2개 | 다음 |
| Repository | 0개 (순수 위임) | 마지막 |

**3차 기준 — 단위 → 통합**

개별 컴포넌트의 단위 테스트로 안정화한 뒤, Controller+Service를 묶는 통합 테스트를 추가했습니다.

```
Auth:      Guard → Util/Repo → Strategy → 통합
FactCheck: Service → Claims → Repo → 통합
ApiKeys:   Service → 통합
```

---

### 테스트 케이스 선정 — 코드 경로 기반 케이스 도출

공개 메서드의 모든 코드 경로를 커버하는 것을 기준으로, 3가지 원칙을 적용했습니다.

**원칙 1 — 공개 메서드의 모든 코드 경로 커버**

각 public method에서 if/else/catch로 분기되는 경로마다 최소 하나의 테스트를 작성했습니다.

```
예시 — exchangeToken() (auth.controller.ts):
코드 경로 3개:
1. 코드 유효 → 토큰 반환            → 정상 경로 테스트
2. Redis에 코드 없음 → INVALID_AUTH_CODE  → 에러 테스트
3. 사용자 없음 → USER_NOT_FOUND      → 에러 테스트
```

**원칙 2 — 사용자 타입별 분기 검증 (Server No-op 패턴)**

게스트와 인증 사용자가 같은 API를 사용하지만 부수효과가 다른 분기를 빠짐없이 테스트했습니다.

| 동작 | 인증 사용자 | 게스트 |
|------|-----------|--------|
| 팩트체크 결과 저장 | DB 저장 | 저장 안 함 |
| 사용량 관리 | 차감 없음 | remainingUses 차감 |
| 도메인 필터 조회 | settings에서 조회 | 빈 필터 사용 |
| apply/ignore | DB 상태 업데이트 | 응답만 반환 |

**원칙 3 — Nullable 필드의 기본값 변환 검증**

DB에서 nullable인 컬럼이 API 응답에서 필수 필드로 변환되는 로직을 검증했습니다.

```typescript
verdict: s.verdict ?? "FALSE"        // null → "FALSE"
sources: (s.sources as ...) ?? []    // null → []
status: s.status ? MAP[s.status] : "pending"  // null → "pending"
```

---

### 주요 설계 결정

| 결정 | 근거 |
|------|------|
| 테스트 트로피 전략 채택 | E2E + 단위만 있는 "모래시계" → 빈 통합 레이어를 채우는 것이 ROI 최대 |
| Mock 팩토리 분리 (`factcheck/testing/factories.ts`) | 2개 spec에서 중복 사용되는 5개 팩토리를 모듈 내 공유 |
| 대칭 위임 메서드 테스트 축소 | `addWhitelist`에서 전체 검증, `addBlacklist`는 위임 확인만 |
| `mockRedisService` 인라인 유지 | 2개 파일 중복은 Rule of Three 미달 |
| DELETE 멱등성 테스트 추가 | RFC 7231 DELETE 멱등성 요구, `deleteMany` → `delete` 변경 시 회귀 방지 |

## ✅ 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?
- [ ] (필요 시) 관련 문서나 API 명세서를 업데이트했나요?

**UI / UX (해당 시)**
- [ ] 다양한 화면 크기(모바일/데스크탑)에서 깨짐이 없나요?
- [ ] 주요 브라우저에서 동작을 확인했나요?

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요?
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)
1. `pnpm test` — 19 suites, 248 tests 전부 통과 확인
2. `pnpm test:e2e` — 기존 E2E 테스트 영향 없음 확인 (DB/Redis 연결 필요)

## ⚠️ 특이사항 (Notes)
- 테스트 전용 PR로, 프로덕션 코드 변경은 없습니다 (기존 feature 커밋은 이미 development에 머지된 내용)
