### PR TITLE
fix: refresh Token 경쟁 상태  해결 및 게스트 IP 해싱 적용

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -30,6 +30,7 @@ import {
   TokenResponse,
   XForwardedFor,
 } from "./types/auth.types";
+import { hashIp } from "./utils/ip-hash.util";
 
 @Controller("auth")
 export class AuthController {
@@ -75,7 +76,8 @@ export class AuthController {
       await this.redisService.set(authCode, authenticatedUser.id, 60000); // 1분 유효
 
       return res.redirect(`${frontendUrl}/auth/callback?code=${authCode}`);
-    } catch {
+    } catch (error) {
+      console.error("Google OAuth callback failed:", error);
       return res.redirect(`${frontendUrl}/login?error=oauth_failed`);
     }
   }
@@ -152,8 +154,9 @@ export class AuthController {
   @Post("guest")
   @Public()
   async guest(@Headers("x-forwarded-for") forwardedFor: XForwardedFor, @Ip() requestIp: string) {
-    // IP 추출: X-Forwarded-For 헤더 또는 @Ip()
-    const ip = forwardedFor ? forwardedFor.split(",")[0].trim() : requestIp;
+    // IP 추출 후 해싱: JWT payload에 원본 IP가 노출되지 않도록 함
+    const rawIp = forwardedFor ? forwardedFor.split(",")[0].trim() : requestIp;
+    const ip = hashIp(rawIp);
 
     // 게스트 정보 조회 또는 생성
     const guestInfo = await this.authService.getOrCreateGuest(ip);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Headers,
   Ip,
+  Logger,
   Post,
   Req,
   Res,
@@ -34,6 +35,8 @@ import { hashIp } from "./utils/ip-hash.util";
 
 @Controller("auth")
 export class AuthController {
+  private readonly logger = new Logger(AuthController.name);
+
   constructor(
     private readonly authService: AuthService,
     private readonly configService: ConfigService,
@@ -77,7 +80,7 @@ export class AuthController {
 
       return res.redirect(`${frontendUrl}/auth/callback?code=${authCode}`);
     } catch (error) {
-      console.error("Google OAuth callback failed:", error);
+      this.logger.error("Google OAuth callback failed", error);
       return res.redirect(`${frontendUrl}/login?error=oauth_failed`);
     }
   }

--- a/src/auth/auth.integration.spec.ts
+++ b/src/auth/auth.integration.spec.ts
@@ -24,6 +24,10 @@ jest.mock("uuid", () => ({
   v4: () => "mock-uuid",
 }));
 
+jest.mock("./utils/ip-hash.util", () => ({
+  hashIp: jest.fn((ip: string) => `hashed-${ip}`),
+}));
+
 const createUser = (overrides?: Partial<{ id: string; email: string; name: string }>) => ({
   id: "user-123",
   email: "test@example.com",
@@ -90,6 +94,7 @@ describe("Auth Integration (Controller + Service)", () => {
     set: jest.fn(),
     get: jest.fn(),
     del: jest.fn(),
+    compareAndSet: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -215,20 +220,20 @@ describe("Auth Integration (Controller + Service)", () => {
         email: user.email,
         jti: "jti-123",
       });
-      mockRedisService.get.mockResolvedValue("valid-refresh-token");
       mockPrismaService.user.findUnique.mockResolvedValue(user);
       mockJwtService.sign
         .mockReturnValueOnce("new-access-token")
         .mockReturnValueOnce("new-refresh-token");
+      mockRedisService.compareAndSet.mockResolvedValue(true);
 
       await controller.refresh(req, tokenResponse);
 
       expect(mockJwtService.verify).toHaveBeenCalledWith("valid-refresh-token", {
         secret: "test-jwt-refresh-secret",
       });
-      expect(mockRedisService.get).toHaveBeenCalledWith(`rt:${user.id}`);
-      expect(mockRedisService.set).toHaveBeenCalledWith(
+      expect(mockRedisService.compareAndSet).toHaveBeenCalledWith(
         `rt:${user.id}`,
+        "valid-refresh-token",
         "new-refresh-token",
         REFRESH_TOKEN_TTL_MS,
       );
@@ -266,7 +271,7 @@ describe("Auth Integration (Controller + Service)", () => {
       );
     });
 
-    it("Redis에 저장된 토큰과 불일치하면 INVALID_REFRESH_TOKEN UnauthorizedException을 던져야 한다", async () => {
+    it("CAS 실패(동시 갱신) 시 INVALID_REFRESH_TOKEN UnauthorizedException을 던져야 한다", async () => {
       const tokenResponse = createTokenResponse();
       const req = createRequestWithCookies("stolen-token");
       mockJwtService.verify.mockReturnValue({
@@ -274,7 +279,9 @@ describe("Auth Integration (Controller + Service)", () => {
         email: "test@example.com",
         jti: "jti-123",
       });
-      mockRedisService.get.mockResolvedValue("different-stored-token");
+      mockPrismaService.user.findUnique.mockResolvedValue(createUser());
+      mockJwtService.sign.mockReturnValue("new-token");
+      mockRedisService.compareAndSet.mockResolvedValue(false);
 
       await expect(controller.refresh(req, tokenResponse)).rejects.toThrow(
         new UnauthorizedException(ERROR_CODES.INVALID_REFRESH_TOKEN),
@@ -306,13 +313,13 @@ describe("Auth Integration (Controller + Service)", () => {
 
       const result = await controller.guest(undefined, "192.168.1.1");
 
-      expect(mockGuestRepository.getGuestInfo).toHaveBeenCalledWith("192.168.1.1");
+      expect(mockGuestRepository.getGuestInfo).toHaveBeenCalledWith("hashed-192.168.1.1");
       expect(mockGuestRepository.setGuestInfo).toHaveBeenCalledTimes(1);
       const setGuestArg = mockGuestRepository.setGuestInfo.mock.calls[0] as [
         string,
         { remainingUses: number; createdAt: number },
       ];
-      expect(setGuestArg[0]).toBe("192.168.1.1");
+      expect(setGuestArg[0]).toBe("hashed-192.168.1.1");
       expect(setGuestArg[1].remainingUses).toBe(GUEST_CONFIG.INITIAL_USES);
       expect(typeof setGuestArg[1].createdAt).toBe("number");
       expect(result).toEqual({
@@ -337,22 +344,22 @@ describe("Auth Integration (Controller + Service)", () => {
       });
     });
 
-    it("X-Forwarded-For 헤더가 있으면 첫 번째 IP를 사용해야 한다", async () => {
+    it("X-Forwarded-For 헤더가 있으면 첫 번째 IP를 해싱하여 사용해야 한다", async () => {
       mockGuestRepository.getGuestInfo.mockResolvedValue(createGuestInfo());
       mockJwtService.sign.mockReturnValue("guest-token");
 
       await controller.guest("10.0.0.1, 10.0.0.2, 10.0.0.3", "192.168.1.1");
 
-      expect(mockGuestRepository.getGuestInfo).toHaveBeenCalledWith("10.0.0.1");
+      expect(mockGuestRepository.getGuestInfo).toHaveBeenCalledWith("hashed-10.0.0.1");
     });
 
-    it("X-Forwarded-For가 없으면 requestIp를 사용해야 한다", async () => {
+    it("X-Forwarded-For가 없으면 requestIp를 해싱하여 사용해야 한다", async () => {
       mockGuestRepository.getGuestInfo.mockResolvedValue(createGuestInfo());
       mockJwtService.sign.mockReturnValue("guest-token");
 
       await controller.guest(undefined, "127.0.0.1");
 
-      expect(mockGuestRepository.getGuestInfo).toHaveBeenCalledWith("127.0.0.1");
+      expect(mockGuestRepository.getGuestInfo).toHaveBeenCalledWith("hashed-127.0.0.1");
     });
   });
 

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -48,6 +48,7 @@ describe("AuthService", () => {
   const mockRedisService = {
     get: jest.fn(),
     set: jest.fn(),
+    compareAndSet: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -132,15 +133,15 @@ describe("AuthService", () => {
     const refreshToken = "valid-refresh-token";
     const payload: UserJwtPayload = { id: "user-id", email: "test@example.com", jti: "uuid" };
 
-    it("리프레시 토큰이 유효하고 Redis와 일치하면 새 토큰을 반환해야 합니다", async () => {
+    it("리프레시 토큰이 유효하고 CAS 성공 시 새 토큰을 반환해야 합니다", async () => {
       // given
       mockJwtService.verify.mockReturnValue(payload);
-      mockRedisService.get.mockResolvedValue(refreshToken); // Redis와 일치
       mockPrismaService.user.findUnique.mockResolvedValue({
         id: "user-id",
         email: "test@example.com",
       });
       mockJwtService.sign.mockReturnValue("new-mock-token");
+      mockRedisService.compareAndSet.mockResolvedValue(true);
 
       // when
       const result = await service.refreshTokens(refreshToken);
@@ -150,27 +151,23 @@ describe("AuthService", () => {
         accessToken: "new-mock-token",
         refreshToken: "new-mock-token",
       });
-      expect(mockRedisService.get).toHaveBeenCalledWith(`rt:${payload.id}`);
-      expect(mockRedisService.set).toHaveBeenCalledWith(
+      expect(mockRedisService.compareAndSet).toHaveBeenCalledWith(
         `rt:${payload.id}`,
+        refreshToken,
         "new-mock-token",
         REFRESH_TOKEN_TTL_MS,
       );
     });
 
-    it("토큰이 Redis에 없으면 UnauthorizedException을 던져야 합니다", async () => {
+    it("CAS 실패 시(동시 갱신) UnauthorizedException을 던져야 합니다", async () => {
       // given
       mockJwtService.verify.mockReturnValue(payload);
-      mockRedisService.get.mockResolvedValue(null); // Redis에 없음 (만료/삭제됨)
-
-      // when & then
-      await expect(service.refreshTokens(refreshToken)).rejects.toThrow(UnauthorizedException);
-    });
-
-    it("토큰이 일치하지 않으면(재사용 시도) UnauthorizedException을 던져야 합니다", async () => {
-      // given
-      mockJwtService.verify.mockReturnValue(payload);
-      mockRedisService.get.mockResolvedValue("different-token"); // Redis 값과 다름
+      mockPrismaService.user.findUnique.mockResolvedValue({
+        id: "user-id",
+        email: "test@example.com",
+      });
+      mockJwtService.sign.mockReturnValue("new-mock-token");
+      mockRedisService.compareAndSet.mockResolvedValue(false); // 동시 요청으로 이미 교체됨
 
       // when & then
       await expect(service.refreshTokens(refreshToken)).rejects.toThrow(UnauthorizedException);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -108,14 +108,6 @@ export class AuthService {
         secret: this.configService.getOrThrow<string>("JWT_REFRESH_SECRET"),
       });
 
-      // Redis에서 저장된 Refresh Token 확인 (Multi-device 로그인 제한 / 탈취 감지)
-      const cachedRefreshToken = await this.redisService.get(`rt:${payload.id}`);
-
-      if (!cachedRefreshToken || cachedRefreshToken !== refreshToken) {
-        this.logger.warn(`토큰 갱신 실패 - Redis 토큰 불일치 (ID: ${payload.id})`);
-        throw new UnauthorizedException(ERROR_CODES.INVALID_REFRESH_TOKEN);
-      }
-
       const user = await this.prisma.user.findUnique({
         where: { id: payload.id },
       });
@@ -126,7 +118,19 @@ export class AuthService {
       }
 
       const tokens = this.generateUserTokens(user.id, user.email);
-      await this.redisService.set(`rt:${user.id}`, tokens.refreshToken, REFRESH_TOKEN_TTL_MS);
+
+      // 원자적 CAS: 기존 토큰 일치 시에만 새 토큰으로 교체 (Race Condition 방지)
+      const success = await this.redisService.compareAndSet(
+        `rt:${user.id}`,
+        refreshToken,
+        tokens.refreshToken,
+        REFRESH_TOKEN_TTL_MS,
+      );
+
+      if (!success) {
+        this.logger.warn(`토큰 갱신 실패 - Redis 토큰 불일치 (ID: ${payload.id})`);
+        throw new UnauthorizedException(ERROR_CODES.INVALID_REFRESH_TOKEN);
+      }
 
       return tokens;
     } catch {

--- a/src/auth/repositories/guest.repository.spec.ts
+++ b/src/auth/repositories/guest.repository.spec.ts
@@ -3,10 +3,6 @@ import { RedisService } from "../../redis/redis.service";
 import { GUEST_CONFIG } from "../constants";
 import { GuestRepository } from "./guest.repository";
 
-jest.mock("../utils/ip-hash.util", () => ({
-  hashIp: jest.fn().mockReturnValue("hashed-ip"),
-}));
-
 describe("GuestRepository", () => {
   let repository: GuestRepository;
 
@@ -40,19 +36,19 @@ describe("GuestRepository", () => {
         createdAt: "1700000000000",
       });
 
-      const result = await repository.getGuestInfo("192.168.1.1");
+      const result = await repository.getGuestInfo("hashed-ip-value");
 
       expect(result).toEqual({
         remainingUses: 3,
         createdAt: 1700000000000,
       });
-      expect(mockRedisClient.hgetall).toHaveBeenCalledWith("guest:hashed-ip");
+      expect(mockRedisClient.hgetall).toHaveBeenCalledWith("guest:hashed-ip-value");
     });
 
     it("데이터가 없으면 null을 반환해야 한다", async () => {
       mockRedisClient.hgetall.mockResolvedValue(null);
 
-      const result = await repository.getGuestInfo("192.168.1.1");
+      const result = await repository.getGuestInfo("hashed-ip-value");
 
       expect(result).toBeNull();
     });
@@ -60,7 +56,7 @@ describe("GuestRepository", () => {
     it("빈 객체면 null을 반환해야 한다", async () => {
       mockRedisClient.hgetall.mockResolvedValue({});
 
-      const result = await repository.getGuestInfo("192.168.1.1");
+      const result = await repository.getGuestInfo("hashed-ip-value");
 
       expect(result).toBeNull();
     });
@@ -70,19 +66,19 @@ describe("GuestRepository", () => {
     const guestInfo = { remainingUses: 3, createdAt: 1700000000000 };
 
     it("Redis Hash에 게스트 정보를 저장해야 한다", async () => {
-      await repository.setGuestInfo("192.168.1.1", guestInfo);
+      await repository.setGuestInfo("hashed-ip-value", guestInfo);
 
-      expect(mockRedisClient.hset).toHaveBeenCalledWith("guest:hashed-ip", {
+      expect(mockRedisClient.hset).toHaveBeenCalledWith("guest:hashed-ip-value", {
         remainingUses: "3",
         createdAt: "1700000000000",
       });
     });
 
     it("기본 TTL을 설정해야 한다", async () => {
-      await repository.setGuestInfo("192.168.1.1", guestInfo);
+      await repository.setGuestInfo("hashed-ip-value", guestInfo);
 
       expect(mockRedisClient.expire).toHaveBeenCalledWith(
-        "guest:hashed-ip",
+        "guest:hashed-ip-value",
         GUEST_CONFIG.TTL_SECONDS,
       );
     });
@@ -90,9 +86,9 @@ describe("GuestRepository", () => {
     it("커스텀 TTL을 적용해야 한다", async () => {
       const customTtl = 3600;
 
-      await repository.setGuestInfo("192.168.1.1", guestInfo, customTtl);
+      await repository.setGuestInfo("hashed-ip-value", guestInfo, customTtl);
 
-      expect(mockRedisClient.expire).toHaveBeenCalledWith("guest:hashed-ip", customTtl);
+      expect(mockRedisClient.expire).toHaveBeenCalledWith("guest:hashed-ip-value", customTtl);
     });
   });
 
@@ -100,15 +96,19 @@ describe("GuestRepository", () => {
     it("hincrby -1로 차감해야 한다", async () => {
       mockRedisClient.hincrby.mockResolvedValue(2);
 
-      await repository.decrementRemainingUses("192.168.1.1");
+      await repository.decrementRemainingUses("hashed-ip-value");
 
-      expect(mockRedisClient.hincrby).toHaveBeenCalledWith("guest:hashed-ip", "remainingUses", -1);
+      expect(mockRedisClient.hincrby).toHaveBeenCalledWith(
+        "guest:hashed-ip-value",
+        "remainingUses",
+        -1,
+      );
     });
 
     it("차감 후 남은 값을 반환해야 한다", async () => {
       mockRedisClient.hincrby.mockResolvedValue(2);
 
-      const result = await repository.decrementRemainingUses("192.168.1.1");
+      const result = await repository.decrementRemainingUses("hashed-ip-value");
 
       expect(result).toBe(2);
     });

--- a/src/auth/repositories/guest.repository.ts
+++ b/src/auth/repositories/guest.repository.ts
@@ -2,7 +2,6 @@ import { Injectable } from "@nestjs/common";
 import { RedisService } from "../../redis/redis.service";
 import { GUEST_CONFIG } from "../constants";
 import type { GuestInfo } from "../types/auth.types";
-import { hashIp } from "../utils/ip-hash.util";
 
 @Injectable()
 export class GuestRepository {
@@ -10,9 +9,9 @@ export class GuestRepository {
 
   /**
    * 게스트 정보 조회 (Redis Hash)
+   * @param hashedIp - 해싱된 IP (controller에서 hashIp() 적용 후 전달)
    */
-  async getGuestInfo(ip: string): Promise<GuestInfo | null> {
-    const hashedIp = hashIp(ip);
+  async getGuestInfo(hashedIp: string): Promise<GuestInfo | null> {
     const data = await this.redisService.getClient().hgetall(`guest:${hashedIp}`);
 
     if (!data || Object.keys(data).length === 0) return null;
@@ -25,13 +24,13 @@ export class GuestRepository {
 
   /**
    * 게스트 정보 저장 (Redis Hash)
+   * @param hashedIp - 해싱된 IP (controller에서 hashIp() 적용 후 전달)
    */
   async setGuestInfo(
-    ip: string,
+    hashedIp: string,
     info: GuestInfo,
     ttlSeconds: number = GUEST_CONFIG.TTL_SECONDS,
   ): Promise<void> {
-    const hashedIp = hashIp(ip);
     const key = `guest:${hashedIp}`;
 
     await this.redisService.getClient().hset(key, {
@@ -43,10 +42,10 @@ export class GuestRepository {
 
   /**
    * 게스트 남은 사용량 차감 (Atomic Operation)
+   * @param hashedIp - 해싱된 IP (controller에서 hashIp() 적용 후 전달)
    * @returns 차감 후 남은 사용량
    */
-  async decrementRemainingUses(ip: string): Promise<number> {
-    const hashedIp = hashIp(ip);
+  async decrementRemainingUses(hashedIp: string): Promise<number> {
     const remaining = await this.redisService
       .getClient()
       .hincrby(`guest:${hashedIp}`, "remainingUses", -1);

--- a/src/common/filters/all-exceptions.filter.spec.ts
+++ b/src/common/filters/all-exceptions.filter.spec.ts
@@ -16,7 +16,7 @@ type MockJsonFn = (_body: JsonBody) => void;
 const createMockHost = (): {
   host: ArgumentsHost;
   mockStatus: jest.Mock;
-  mockJson: jest.MockWithArgs<MockJsonFn>;
+  mockJson: jest.Mock<void, [JsonBody]>;
 } => {
   const jsonNoop: MockJsonFn = () => {};
   const mockJson = jest.fn(jsonNoop);
@@ -41,7 +41,7 @@ describe("AllExceptionsFilter", () => {
   let devFilter: AllExceptionsFilter;
   let host: ArgumentsHost;
   let mockStatus: jest.Mock;
-  let mockJson: jest.MockWithArgs<MockJsonFn>;
+  let mockJson: jest.Mock<void, [JsonBody]>;
 
   const mockConfigService = {
     get: jest.fn().mockReturnValue("production"),

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -54,4 +54,28 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
   async del(key: string): Promise<void> {
     await this.client.del(key);
   }
+
+  /**
+   * 원자적 Compare-And-Set (Lua 스크립트)
+   * 기존 값이 expected와 일치할 때만 newValue로 교체
+   * @returns 교체 성공 여부
+   */
+  async compareAndSet(
+    key: string,
+    expected: string,
+    newValue: string,
+    ttlMs: number,
+  ): Promise<boolean> {
+    const script = `
+      local current = redis.call('GET', KEYS[1])
+      if current == ARGV[1] then
+        redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[3])
+        return 1
+      else
+        return 0
+      end
+    `;
+    const result = await this.client.eval(script, 1, key, expected, newValue, ttlMs.toString());
+    return result === 1;
+  }
 }


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Fixes #24 

## 🛠️ 작업 내용 (Description)

### 1. Refresh Token 갱신 Race Condition 해결
### (`src/auth/auth.service.ts`, `src/redis/redis.service.ts`)
- AS-IS: `refreshTokens()`에서 Redis 토큰 검증(`GET`)과 새 토큰 저장(`SET`) 사이에 원자성이 보장되지 않아, 동시 요청 시 한 쪽 세션이 끊김
- TO-BE:
  - `RedisService`에 Lua 스크립트 기반 `compareAndSet()` 메서드 추가 — 기존 값이 expected와 일치할 때만 새 값으로 교체하는 원자적 CAS 연산
  - `refreshTokens()`에서 기존 `GET` → 비교 → `SET` 흐름을 `compareAndSet()` 단일 호출로 교체
  - CAS 실패 시(다른 요청이 먼저 갱신) `UnauthorizedException` 반환

### 2. 게스트 JWT에서 원본 IP 노출 제거 (`src/auth/auth.controller.ts`)
- AS-IS: `guest()` 엔드포인트에서 원본 IP를 그대로 `generateGuestToken(ip)`에 전달하여 JWT payload에 평문 IP 포함 — base64 디코딩만으로 누구나 열람 가능
- TO-BE: controller에서 `hashIp(rawIp)`를 먼저 적용한 뒤 해시된 값을 `generateGuestToken()`과 `getOrCreateGuest()`에 전달 — JWT payload에는 해시된 IP만 포함

**변경 파일 (3개)**

| 파일 | 변경 내용 |
|---|---|
| `src/redis/redis.service.ts` | `compareAndSet()` 메서드 추가 (Lua 스크립트 기반 원자적 CAS) |
| `src/auth/auth.service.ts` | `refreshTokens()`에서 `compareAndSet()` 사용으로 Race Condition 제거 |
| `src/auth/auth.controller.ts` | `guest()`에서 `hashIp(rawIp)` 적용 후 토큰 생성에 전달 |

## ✅ 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요?
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)

### 1. Race Condition 해결
1. OAuth 로그인 후 브라우저 탭 2개 열기
2. DevTools에서 두 탭의 accessToken을 만료된 값으로 변경
3. 두 탭에서 거의 동시에 API 호출 실행
4. 한 탭은 정상 갱신, 다른 탭은 401 → FE 인터셉터에서 재갱신 흐름 확인
5. 두 탭 모두 최종적으로 정상 동작하는지 확인

### 2. IP 노출 제거
1. 게스트로 접속하여 accessToken 획득
2. [jwt.io](https://jwt.io)에서 토큰 디코딩
3. `ip` 필드에 원본 IP가 아닌 SHA-256 해시 값이 들어있는지 확인

## ⚠️ 특이사항 (Notes)
- `compareAndSet()`은 Redis Lua 스크립트를 사용하므로 단일 Redis 노드에서 원자성이 보장됩니다. Redis Cluster 환경에서는 키가 동일 슬롯에 있으므로 정상 동작합니다.